### PR TITLE
docs: add initial project planning prompt

### DIFF
--- a/initial-prompt.md
+++ b/initial-prompt.md
@@ -1,0 +1,17 @@
+# Initial Project Planning Prompt
+
+## Original Request (原始需求)
+
+我现在想用Quarto的API来create一个网站，网站topbar包含以下几部分，Home, Report, Viz. Home page提供overview of the project, Report会把paper的内容粘贴进来，Home page和report page都需要能支持md格式，Viz可能会有几个section,具体参考这个网站https://luminite.shinyapps.io/ukb-mdrmf/。
+
+将你的想法写成plans
+
+## Translation (翻译)
+
+I want to use Quarto's API to create a website. The website topbar should include the following sections: Home, Report, Viz. The Home page provides an overview of the project, Report will paste the paper content, both Home page and Report page need to support markdown format, Viz may have several sections, refer to this website for specifics: https://luminite.shinyapps.io/ukb-mdrmf/.
+
+Write your ideas into plans.
+
+## Reference Website
+
+- Example visualization website: https://luminite.shinyapps.io/ukb-mdrmf/


### PR DESCRIPTION
Add the original project planning prompt in markdown format with both Chinese and English versions, including reference website.

Closes #2

Generated with [Claude Code](https://claude.ai/code)