### PR TITLE
feat: remove author names while preserving author UI components

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -84,8 +84,6 @@ A case study on five primary fibrotic and closely related diseases — coronary 
 
 ## Research Team
 
-Xiayuan Huang^1^, Hang Zhou^1^, Yitao Hong^1^, Xin Zhou^1^, Johann de Jong^2,\*^, Zuoheng Wang^1,\*^
-
 ^1^Yale University, New Haven, CT, USA
 ^2^UCB Biosciences GmbH, Monheim am Rhein, Germany
 ^\*^Equal contribution as co-senior authors

--- a/report/paper1.qmd
+++ b/report/paper1.qmd
@@ -2,29 +2,23 @@
 title: "Multimodal Data Integration Improves Disease Risk Prediction in the UK Biobank"
 description: "ALIGATEHR-Gen: a graph attention network integrating EHR, genetic data, and medical ontology for disease risk prediction across 118 diseases"
 author:
-  - name: Xiayuan Huang
-    affiliations:
+  - affiliations:
       - name: Yale University
         department: Department of Biostatistics
         city: New Haven
         region: CT
         country: USA
-  - name: Hang Zhou
-    affiliations:
+  - affiliations:
       - name: Yale University
-  - name: Yitao Hong
-    affiliations:
+  - affiliations:
       - name: Yale University
-  - name: Xin Zhou
-    affiliations:
+  - affiliations:
       - name: Yale University
-  - name: Johann de Jong
-    affiliations:
+  - affiliations:
       - name: UCB Biosciences GmbH
         city: Monheim am Rhein
         country: Germany
-  - name: Zuoheng Wang
-    affiliations:
+  - affiliations:
       - name: Yale University
 date: "2025-01-01"
 categories: [graph-neural-network, EHR, genetic-data, disease-risk-prediction, UK-Biobank]


### PR DESCRIPTION
Removes all author names from paper1.qmd YAML frontmatter and the index.qmd Research Team section while keeping affiliations and structural components intact.

Closes #6

Generated with [Claude Code](https://claude.ai/code)