### PR TITLE
Build the confirmed Demo Profile flow

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -4,6 +4,7 @@ project:
   resources:
     - chatbot/chatbot.css
     - chatbot/embedding-demo.js
+    - chatbot/profile-session.js
     - chatbot/chatbot.js
   preview:
     port: 4200

--- a/chatbot-backend/app.py
+++ b/chatbot-backend/app.py
@@ -1,11 +1,12 @@
 import os
 import re
 from contextlib import asynccontextmanager
+from typing import Literal
 
 from openai import OpenAI, APIError
 from fastapi import FastAPI, HTTPException, Query, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from paper_context import PAPER_TEXT
 from data_query import query_data, format_data_context, match_disease, is_pathway_query, is_embedding_query
@@ -13,6 +14,13 @@ from clinical_form import get_available_diseases, get_form_fields
 from risk_assessment import query_patient_risk
 from followup import get_pathway_enrichment, describe_embedding_context
 from fibrotic_release import load_fibrotic_release
+from demo_profile import (
+    FEATURE_EXTRACTION_SYSTEM_PROMPT,
+    ProfileRateLimiter,
+    build_profile_draft,
+    confirm_profile,
+    parse_feature_candidates,
+)
 
 INTENT_SYSTEM_PROMPT = (
     "You are an intent classifier. Given a user message, classify it into exactly one "
@@ -48,8 +56,10 @@ PAPER_QA_SYSTEM_PROMPT = (
 )
 
 CLINICAL_PROMPT = (
-    "I can help assess your risk for the following diseases. "
-    "Please select one to begin the clinical risk assessment:"
+    "I can help you build a synthetic or sufficiently de-identified Demo Profile "
+    "for a research comparison. This is not medical advice, diagnosis, or a personal "
+    "outcome prediction. Do not enter names, exact birth dates, addresses, patient "
+    "IDs, or real medical records."
 )
 
 DATA_QUERY_SYSTEM_PROMPT = (
@@ -102,6 +112,35 @@ class ChatResponse(BaseModel):
     ui: dict | None = None
 
 
+class FeatureCandidate(BaseModel):
+    field: str = Field(min_length=1, max_length=80)
+    raw_value: str | float | int | bool | None
+    raw_unit: str | None = Field(default=None, max_length=40)
+    source_text: str = Field(min_length=1, max_length=500)
+    operation: Literal["set", "correct", "remove"] = "set"
+
+
+class ProfileExtractRequest(BaseModel):
+    message: str = Field(min_length=1, max_length=2000)
+
+
+class ProfileExtractResponse(BaseModel):
+    candidates: list[FeatureCandidate]
+
+
+class ProfileValidateRequest(BaseModel):
+    candidates: list[FeatureCandidate] = Field(max_length=100)
+
+
+class ProfileDraftInput(BaseModel):
+    state: str
+    candidates: list[FeatureCandidate] = Field(max_length=100)
+
+
+class ProfileConfirmRequest(BaseModel):
+    draft: ProfileDraftInput
+
+
 class FormFieldsResponse(BaseModel):
     disease: str
     disease_label: str
@@ -135,6 +174,13 @@ class AssessResponse(BaseModel):
 
 
 client: OpenAI | None = None
+profile_rate_limiter = ProfileRateLimiter()
+
+
+def enforce_profile_rate_limit(request):
+    client_key = request.client.host if request.client else "unknown"
+    if not profile_rate_limiter.allow(client_key):
+        raise HTTPException(status_code=429, detail="Too many profile requests")
 
 
 @asynccontextmanager
@@ -206,6 +252,46 @@ async def fibrotic_preset(response: Response):
     return preset
 
 
+@app.post("/profile/extract", response_model=ProfileExtractResponse)
+async def profile_extract(req: ProfileExtractRequest, request: Request):
+    enforce_profile_rate_limit(request)
+    if client is None:
+        raise HTTPException(status_code=503, detail="LLM API key not configured")
+    try:
+        response = client.chat.completions.create(
+            model="deepseek-chat",
+            max_tokens=900,
+            temperature=0,
+            messages=[
+                {"role": "system", "content": FEATURE_EXTRACTION_SYSTEM_PROMPT},
+                {"role": "user", "content": req.message},
+            ],
+        )
+        candidates = parse_feature_candidates(
+            req.message, response.choices[0].message.content
+        )
+    except APIError as error:
+        raise HTTPException(status_code=502, detail=f"LLM API error: {error.message}")
+    except (AttributeError, ValueError) as error:
+        raise HTTPException(status_code=502, detail=str(error))
+    return {"candidates": candidates}
+
+
+@app.post("/profile/validate")
+async def profile_validate(req: ProfileValidateRequest, request: Request):
+    enforce_profile_rate_limit(request)
+    return build_profile_draft([candidate.model_dump() for candidate in req.candidates])
+
+
+@app.post("/profile/confirm")
+async def profile_confirm(req: ProfileConfirmRequest, request: Request):
+    enforce_profile_rate_limit(request)
+    try:
+        return confirm_profile(req.draft.model_dump())
+    except ValueError as error:
+        raise HTTPException(status_code=409, detail=str(error))
+
+
 @app.get("/form-fields", response_model=FormFieldsResponse)
 async def form_fields(disease: str = Query(min_length=1)):
     result = get_form_fields(disease)
@@ -248,11 +334,10 @@ async def chat(req: ChatRequest):
         raise HTTPException(status_code=502, detail=f"LLM API error: {e.message}")
 
     if intent == "clinical":
-        diseases = get_available_diseases()
         return ChatResponse(
             reply=CLINICAL_PROMPT,
             intent=intent,
-            ui={"type": "disease_select", "diseases": diseases},
+            ui={"type": "demo_profile_start"},
         )
 
     if intent == "data_query":

--- a/chatbot-backend/demo_profile.py
+++ b/chatbot-backend/demo_profile.py
@@ -1,0 +1,658 @@
+"""Deterministic Demo Profile validation.
+
+The LLM-facing extraction boundary may propose Feature Candidates, but this
+module is the authority for units, field state, derivation, and confirmation.
+See the accepted design at commit 79b16b4, sections 5, 10, 11, and 13.
+"""
+
+import json
+import re
+import time
+from collections import defaultdict, deque
+from copy import deepcopy
+
+
+BLOCKING_STATUSES = {"ambiguous", "out_of_range", "conflicting"}
+USABLE_STATUSES = {"valid", "outside_reference_support"}
+
+FEATURE_EXTRACTION_SYSTEM_PROMPT = """You extract Feature Candidates for a research Demo Profile.
+Return one JSON object with a single `candidates` array. Each candidate must contain:
+`field`, `raw_value`, `raw_unit`, `source_text`, and `operation`.
+
+Allowed operations are `set`, `correct`, and `remove`. Copy `source_text` exactly from
+the visitor message. Use a unit only when it is explicit in that exact source text.
+Do not validate, normalize, calculate, infer missing values, confirm a profile, match a
+cohort, infer sex, or generate ICD codes. Preserve unsupported fields as candidates.
+Return JSON only.
+"""
+
+# These support bounds come from the current committed fibrotic demo cohort.
+# They flag cohort coverage only; they are not medical reference intervals.
+REFERENCE_SUPPORT = {
+    "age": (33, 90),
+    "height": (140, 210),
+    "weight": (37.6, 165.8),
+    "bmi": (15, 60),
+    "waist": (50.7, 163.1),
+    "hip": (65.3, 177.5),
+    "dbp": (46, 120),
+    "sbp": (80, 220),
+    "creatinine": (20.4, 500),
+    "hba1c": (20, 113),
+}
+
+# Operational parser bounds reject obvious unit/entry errors before cohort
+# support is considered. They are deliberately broad, are tested to contain the
+# full current demo-cohort support, and are not healthy or diagnostic ranges.
+# A Dataset Release change must rerun that validation before these are retained.
+INPUT_BOUNDS = {
+    "age": (0, 130),
+    "height": (50, 300),
+    "weight": (1, 500),
+    "bmi": (5, 150),
+    "waist": (20, 300),
+    "hip": (20, 300),
+    "dbp": (20, 250),
+    "sbp": (30, 350),
+    "creatinine": (1, 5000),
+    "hba1c": (1, 250),
+}
+
+FIELD_ALIASES = {
+    "age": "age",
+    "age_recruit": "age",
+    "sex": "sex",
+    "height": "height",
+    "weight": "weight",
+    "bmi": "bmi",
+    "waist": "waist",
+    "waist_circumference": "waist",
+    "hip": "hip",
+    "hip_circumference": "hip",
+    "blood_pressure": "blood_pressure",
+    "bp": "blood_pressure",
+    "sbp": "sbp",
+    "systolic_blood_pressure": "sbp",
+    "dbp": "dbp",
+    "diastolic_blood_pressure": "dbp",
+    "smoking": "smoking_status",
+    "smoking_status": "smoking_status",
+    "alcohol": "alcohol_frequency",
+    "alcohol_freq": "alcohol_frequency",
+    "alcohol_frequency": "alcohol_frequency",
+    "affected_relative": "affected_relative",
+    "affected_relative_status": "affected_relative",
+    "family_history": "affected_relative",
+    "has_affected_rel": "affected_relative",
+    "creatinine": "creatinine",
+    "hba1c": "hba1c",
+    "hba1c_percent": "hba1c",
+}
+
+FIELD_META = {
+    "age": ("Age", "demographics", "years"),
+    "sex": ("Sex", "demographics", None),
+    "height": ("Height", "body_composition", "cm"),
+    "weight": ("Weight", "body_composition", "kg"),
+    "bmi": ("BMI", "body_composition", "kg/m²"),
+    "waist": ("Waist circumference", "body_composition", "cm"),
+    "hip": ("Hip circumference", "body_composition", "cm"),
+    "sbp": ("Systolic blood pressure", "blood_pressure", "mmHg"),
+    "dbp": ("Diastolic blood pressure", "blood_pressure", "mmHg"),
+    "smoking_status": ("Smoking status", "lifestyle", None),
+    "alcohol_frequency": ("Alcohol frequency", "lifestyle", None),
+    "affected_relative": ("Affected relative", "family_history", None),
+    "creatinine": ("Creatinine", "optional_laboratory", "µmol/L"),
+    "hba1c": ("HbA1c", "optional_laboratory", "mmol/mol"),
+}
+
+
+class AmbiguousValue(ValueError):
+    pass
+
+
+class OutsideInputRange(ValueError):
+    pass
+
+
+class ProfileRateLimiter:
+    def __init__(self, limit=20, window_seconds=60):
+        self.limit = limit
+        self.window_seconds = window_seconds
+        self._requests = defaultdict(deque)
+
+    def allow(self, key, now=None):
+        now = time.monotonic() if now is None else now
+        requests = self._requests[key]
+        while requests and requests[0] <= now - self.window_seconds:
+            requests.popleft()
+        if len(requests) >= self.limit:
+            return False
+        requests.append(now)
+        return True
+
+
+def parse_feature_candidates(message, raw_content):
+    content = raw_content.strip()
+    try:
+        payload = json.loads(content)
+    except json.JSONDecodeError as error:
+        raise ValueError("Feature extraction did not return valid JSON") from error
+    candidates = payload.get("candidates") if isinstance(payload, dict) else None
+    if not isinstance(candidates, list):
+        raise ValueError("Feature extraction did not return a candidates array")
+    required = {"field", "raw_value", "raw_unit", "source_text", "operation"}
+    for candidate in candidates:
+        if not isinstance(candidate, dict) or set(candidate) != required:
+            raise ValueError("Feature Candidate contract is invalid")
+        if candidate["operation"] not in {"set", "correct", "remove"}:
+            raise ValueError("Feature Candidate operation is invalid")
+        if not candidate["source_text"] or candidate["source_text"] not in message:
+            raise ValueError("Feature Candidate source text must be copied from the message")
+    return candidates
+
+
+def _number(value):
+    if isinstance(value, bool) or value is None or value == "":
+        raise AmbiguousValue("missing numeric value")
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as error:
+        raise AmbiguousValue("value is not numeric") from error
+    if result != result or result in {float("inf"), float("-inf")}:
+        raise AmbiguousValue("value is not finite")
+    return result
+
+
+def _unit_key(unit):
+    return (unit or "").strip().lower().replace(" ", "")
+
+
+def _unit_is_explicit(field, unit, source_text):
+    key = _unit_key(unit).replace("μ", "µ")
+    patterns = {
+        "cm": r"\bcm\b|\bcentimeters?\b",
+        "m": r"\bmeters?\b|(?<![a-z])m(?![a-z])",
+        "in": r"\bin(?:ch|ches)?\b|\"",
+        "ft": r"\bft\b|\bfoot\b|\bfeet\b|'",
+        "kg": r"\bkg\b|\bkilograms?\b",
+        "lb": r"\blbs?\b|\bpounds?\b",
+        "µmol/l": r"(?:µ|μ|u)mol\s*/\s*l|micromol\s*/\s*l",
+        "mg/dl": r"mg\s*/\s*dl",
+        "%": r"%|\bpercent\b|\bpct\b",
+        "mmol/mol": r"mmol\s*/\s*mol",
+        "years": r"\byears?\b|\byrs?\b",
+        "kg/m2": r"kg\s*/\s*m(?:2|²)",
+        "mmhg": r"\bmm\s*hg\b",
+    }
+    aliases = {
+        "centimeter": "cm",
+        "centimeters": "cm",
+        "meter": "m",
+        "meters": "m",
+        "inch": "in",
+        "inches": "in",
+        "foot": "ft",
+        "feet": "ft",
+        "kilogram": "kg",
+        "kilograms": "kg",
+        "lbs": "lb",
+        "pound": "lb",
+        "pounds": "lb",
+        "umol/l": "µmol/l",
+        "micromol/l": "µmol/l",
+        "mgdl": "mg/dl",
+        "percent": "%",
+        "pct": "%",
+        "mmolmol": "mmol/mol",
+        "year": "years",
+        "yr": "years",
+        "yrs": "years",
+        "kg/m²": "kg/m2",
+        "kgm2": "kg/m2",
+        "kgm²": "kg/m2",
+        "mmhg.": "mmhg",
+    }
+    if field in {"height", "waist", "hip"} and key in {"ft/in", "ft+in"}:
+        return bool(re.search(patterns["ft"], source_text, re.IGNORECASE)) and bool(
+            re.search(patterns["in"], source_text, re.IGNORECASE)
+        )
+    canonical = aliases.get(key, key)
+    pattern = patterns.get(canonical)
+    return bool(pattern and re.search(pattern, source_text, re.IGNORECASE))
+
+
+def _with_unit(value, unit, factors, label):
+    value = _number(value)
+    key = _unit_key(unit)
+    if key not in factors:
+        raise AmbiguousValue(f"unsupported or missing {label} unit")
+    return value * factors[key]
+
+
+def _normalize_length(value, unit):
+    if isinstance(value, str):
+        compound = re.fullmatch(
+            r"\s*(\d+(?:\.\d+)?)\s*(?:ft|foot|feet|')\s*"
+            r"(\d+(?:\.\d+)?)\s*(?:in|inch|inches|\")\s*",
+            value,
+            re.IGNORECASE,
+        )
+        if compound:
+            feet = float(compound.group(1))
+            inches = float(compound.group(2))
+            return round(feet * 30.48 + inches * 2.54, 2)
+    factors = {
+        "cm": 1,
+        "centimeter": 1,
+        "centimeters": 1,
+        "m": 100,
+        "meter": 100,
+        "meters": 100,
+        "in": 2.54,
+        "inch": 2.54,
+        "inches": 2.54,
+        "ft": 30.48,
+        "foot": 30.48,
+        "feet": 30.48,
+    }
+    return round(_with_unit(value, unit, factors, "length"), 2)
+
+
+def _normalize_weight(value, unit):
+    factors = {
+        "kg": 1,
+        "kilogram": 1,
+        "kilograms": 1,
+        "lb": 0.45359237,
+        "lbs": 0.45359237,
+        "pound": 0.45359237,
+        "pounds": 0.45359237,
+    }
+    return round(_with_unit(value, unit, factors, "weight"), 2)
+
+
+def _normalize_plain(value, unit, accepted_units, label):
+    value = _number(value)
+    if _unit_key(unit) not in accepted_units:
+        raise AmbiguousValue(f"unsupported or missing {label} unit")
+    return value
+
+
+def _normalize_creatinine(value, unit):
+    value = _number(value)
+    key = _unit_key(unit).replace("μ", "µ")
+    if key in {"µmol/l", "umol/l", "micromol/l"}:
+        return round(value, 2)
+    if key in {"mg/dl", "mgdl"}:
+        return round(value * 88.4, 2)
+    raise AmbiguousValue("unsupported or missing creatinine unit")
+
+
+def _normalize_hba1c(value, unit):
+    value = _number(value)
+    key = _unit_key(unit)
+    if key in {"mmol/mol", "mmolmol"}:
+        return round(value, 1)
+    if key in {"%", "percent", "pct"}:
+        return round((value - 2.15) * 10.929, 1)
+    raise AmbiguousValue("unsupported or missing HbA1c unit")
+
+
+def _canonical_text(value):
+    return re.sub(r"[^a-z0-9]+", " ", str(value).strip().lower()).strip()
+
+
+def _normalize_category(field, value):
+    key = _canonical_text(value)
+    maps = {
+        "sex": {
+            "female": "female",
+            "woman": "female",
+            "male": "male",
+            "man": "male",
+        },
+        "smoking_status": {
+            "never": "never",
+            "never smoked": "never",
+            "former": "former",
+            "former smoker": "former",
+            "previous": "former",
+            "current": "current",
+            "current smoker": "current",
+        },
+        "alcohol_frequency": {
+            "never": "never",
+            "special occasions only": "special_occasions",
+            "special occasions": "special_occasions",
+            "monthly": "one_to_three_per_month",
+            "1 3 times a month": "one_to_three_per_month",
+            "once or twice a week": "one_to_two_per_week",
+            "1 2 times a week": "one_to_two_per_week",
+            "three or four times a week": "three_to_four_per_week",
+            "3 4 times a week": "three_to_four_per_week",
+            "daily": "daily_or_almost_daily",
+            "daily or almost daily": "daily_or_almost_daily",
+        },
+        "affected_relative": {
+            "yes": True,
+            "true": True,
+            "affected": True,
+            "no": False,
+            "false": False,
+            "none": False,
+        },
+    }
+    if key not in maps[field]:
+        raise AmbiguousValue(f"unsupported {field} category")
+    return maps[field][key]
+
+
+def _normalize(field, value, unit):
+    if field in {"sex", "smoking_status", "alcohol_frequency", "affected_relative"}:
+        return _normalize_category(field, value)
+    if field in {"height", "waist", "hip"}:
+        return _normalize_length(value, unit)
+    if field == "weight":
+        return _normalize_weight(value, unit)
+    if field == "age":
+        value = _normalize_plain(value, unit, {"", "year", "years", "yr", "yrs"}, "age")
+        if not value.is_integer():
+            raise AmbiguousValue("age must be expressed in whole years")
+        return int(value)
+    if field == "bmi":
+        return round(
+            _normalize_plain(
+                value,
+                unit,
+                {"", "kg/m2", "kg/m²", "kgm2", "kgm²"},
+                "BMI",
+            ),
+            1,
+        )
+    if field in {"sbp", "dbp"}:
+        return round(
+            _normalize_plain(value, unit, {"", "mmhg", "mmhg."}, "blood pressure")
+        )
+    if field == "creatinine":
+        return _normalize_creatinine(value, unit)
+    if field == "hba1c":
+        return _normalize_hba1c(value, unit)
+    raise AmbiguousValue("unsupported field")
+
+
+def _status_for_value(field, value):
+    if field not in INPUT_BOUNDS:
+        return "valid"
+    lower, upper = INPUT_BOUNDS[field]
+    if value < lower or value > upper:
+        raise OutsideInputRange(f"{field} falls outside accepted input bounds")
+    support_lower, support_upper = REFERENCE_SUPPORT[field]
+    if value < support_lower or value > support_upper:
+        return "outside_reference_support"
+    return "valid"
+
+
+def _derived_status(field, value):
+    try:
+        return _status_for_value(field, value), None
+    except OutsideInputRange as error:
+        return "out_of_range", str(error)
+
+
+def _base_feature(field, candidate):
+    label, domain, unit = FIELD_META.get(
+        field, (field.replace("_", " ").title(), "unsupported", None)
+    )
+    return {
+        "label": label,
+        "domain": domain,
+        "status": "unsupported" if field not in FIELD_META else "ambiguous",
+        "original_value": candidate.get("raw_value"),
+        "original_unit": candidate.get("raw_unit"),
+        "normalized_value": None,
+        "normalized_unit": None,
+        "expected_unit": unit,
+        "source_text": candidate.get("source_text", ""),
+        "operation": candidate.get("operation", "set"),
+        "source_history": [
+            {
+                "source_text": candidate.get("source_text", ""),
+                "original_value": candidate.get("raw_value"),
+                "original_unit": candidate.get("raw_unit"),
+                "operation": candidate.get("operation", "set"),
+            }
+        ],
+    }
+
+
+def _candidate_feature(field, candidate):
+    feature = _base_feature(field, candidate)
+    if field not in FIELD_META:
+        return feature
+    try:
+        supplied_unit = candidate.get("raw_unit")
+        if (
+            supplied_unit
+            and not candidate.get("_unit_from_existing")
+            and not candidate.get("_unit_from_schema")
+            and not _unit_is_explicit(
+                field, supplied_unit, candidate.get("source_text", "")
+            )
+        ):
+            raise AmbiguousValue("measurement unit is not explicit in the source text")
+        if (
+            field in {"height", "weight", "waist", "hip", "creatinine", "hba1c"}
+            and not supplied_unit
+            and not candidate.get("_unit_from_existing")
+        ):
+            raise AmbiguousValue("measurement unit is missing from the source text")
+        value = _normalize(field, candidate.get("raw_value"), candidate.get("raw_unit"))
+        feature["normalized_value"] = value
+        feature["normalized_unit"] = FIELD_META[field][2]
+        feature["status"] = _status_for_value(field, value)
+    except AmbiguousValue as error:
+        feature["status"] = "ambiguous"
+        feature["message"] = str(error)
+    except OutsideInputRange as error:
+        feature["status"] = "out_of_range"
+        feature["message"] = str(error)
+    return feature
+
+
+def _same_value(left, right):
+    return (
+        left.get("normalized_value") == right.get("normalized_value")
+        and left.get("normalized_unit") == right.get("normalized_unit")
+        and left.get("status") == right.get("status")
+    )
+
+
+def _merge_feature(current, incoming):
+    operation = incoming.get("operation", "set")
+    if current is None:
+        return incoming
+    if operation == "correct":
+        incoming["source_history"] = (
+            current.get("source_history", []) + incoming.get("source_history", [])
+        )
+        return incoming
+    if _same_value(current, incoming):
+        return current
+    alternatives = list(current.get("alternatives", []))
+    if not alternatives:
+        alternatives.append(current.get("normalized_value", current.get("original_value")))
+    value = incoming.get("normalized_value", incoming.get("original_value"))
+    if value not in alternatives:
+        alternatives.append(value)
+    merged = deepcopy(current)
+    merged["status"] = "conflicting"
+    merged["alternatives"] = alternatives
+    merged["source_texts"] = list(
+        dict.fromkeys(
+            current.get("source_texts", [current.get("source_text", "")])
+            + [incoming.get("source_text", "")]
+        )
+    )
+    merged["source_history"] = (
+        current.get("source_history", []) + incoming.get("source_history", [])
+    )
+    merged["message"] = "Conflicting values require an explicit correction."
+    return merged
+
+
+def _expand_blood_pressure(candidate):
+    raw = str(candidate.get("raw_value", ""))
+    match = re.fullmatch(r"\s*(\d+(?:\.\d+)?)\s*/\s*(\d+(?:\.\d+)?)\s*", raw)
+    if not match:
+        return None
+    expanded = []
+    for field, value in (("sbp", match.group(1)), ("dbp", match.group(2))):
+        part = deepcopy(candidate)
+        part["field"] = field
+        part["raw_value"] = float(value)
+        part["raw_unit"] = candidate.get("raw_unit") or "mmHg"
+        if candidate.get("raw_unit") is None:
+            part["_unit_from_schema"] = True
+        expanded.append(part)
+    return expanded
+
+
+def _missing_fields(reported, derived):
+    missing = [field for field in FIELD_META if field not in reported]
+    if "bmi" in derived and "bmi" in missing:
+        missing.remove("bmi")
+    return missing
+
+
+def build_profile_draft(candidates):
+    reported = {}
+    for original in candidates:
+        candidate = deepcopy(original)
+        raw_field = re.sub(r"[^a-z0-9]+", "_", str(candidate.get("field", "")).lower()).strip("_")
+        field = FIELD_ALIASES.get(raw_field, raw_field or "unknown")
+        operation = candidate.get("operation", "set")
+        if operation not in {"set", "correct", "remove"}:
+            feature = _base_feature(field, candidate)
+            feature.update(
+                status="ambiguous",
+                message="Feature Candidate operation is invalid.",
+            )
+            reported[field] = _merge_feature(reported.get(field), feature)
+            continue
+        candidate["operation"] = operation
+
+        if field == "blood_pressure":
+            expanded = _expand_blood_pressure(candidate)
+            if expanded is None:
+                feature = _base_feature(field, candidate)
+                feature.update(
+                    status="ambiguous",
+                    message="Blood pressure must contain visible SBP/DBP values.",
+                )
+                reported[field] = _merge_feature(reported.get(field), feature)
+                continue
+            candidates_to_apply = expanded
+        else:
+            candidate["field"] = field
+            candidates_to_apply = [candidate]
+
+        for item in candidates_to_apply:
+            item_field = item["field"]
+            if operation == "remove":
+                reported.pop(item_field, None)
+                continue
+            current = reported.get(item_field)
+            if (
+                operation == "correct"
+                and item.get("raw_unit") is None
+                and current
+                and current.get("normalized_unit")
+            ):
+                item["raw_unit"] = current["normalized_unit"]
+                item["_unit_from_existing"] = True
+            incoming = _candidate_feature(item_field, item)
+            reported[item_field] = _merge_feature(current, incoming)
+
+    derived = {}
+    height = reported.get("height")
+    weight = reported.get("weight")
+    if (
+        height
+        and weight
+        and height["status"] in USABLE_STATUSES
+        and weight["status"] in USABLE_STATUSES
+    ):
+        bmi = weight["normalized_value"] / (height["normalized_value"] / 100) ** 2
+        bmi = round(bmi, 1)
+        bmi_status, bmi_message = _derived_status("bmi", bmi)
+        derived["bmi"] = {
+            "label": "BMI",
+            "value": bmi,
+            "unit": "kg/m²",
+            "domain": "body_composition",
+            "status": bmi_status,
+            "derived_from": ["height", "weight"],
+        }
+        if bmi_message:
+            derived["bmi"]["message"] = bmi_message
+        reported_bmi = reported.get("bmi")
+        if (
+            reported_bmi
+            and reported_bmi["status"] in USABLE_STATUSES
+            and abs(reported_bmi["normalized_value"] - bmi) > 0.1
+        ):
+            reported_bmi["calculated_value"] = bmi
+            if reported_bmi.get("operation") == "correct":
+                reported_bmi["mismatch_acknowledged"] = True
+                reported_bmi["message"] = (
+                    "Reported BMI was explicitly confirmed despite differing from "
+                    "the calculated BMI."
+                )
+            else:
+                reported_bmi["status"] = "conflicting"
+                reported_bmi["message"] = (
+                    "Reported BMI differs from BMI calculated from height and weight."
+                )
+
+    waist = reported.get("waist")
+    hip = reported.get("hip")
+    if (
+        waist
+        and hip
+        and waist["status"] in USABLE_STATUSES
+        and hip["status"] in USABLE_STATUSES
+        and hip["normalized_value"] > 0
+    ):
+        derived["waist_to_hip_ratio"] = {
+            "label": "Waist-to-hip ratio",
+            "value": round(waist["normalized_value"] / hip["normalized_value"], 2),
+            "unit": "ratio",
+            "domain": "body_composition",
+            "status": "valid",
+            "derived_from": ["waist", "hip"],
+        }
+
+    statuses = {feature["status"] for feature in reported.values()} | {
+        feature["status"] for feature in derived.values()
+    }
+    usable_count = sum(
+        feature["status"] in USABLE_STATUSES for feature in reported.values()
+    )
+    return {
+        "state": "draft",
+        "candidates": deepcopy(candidates),
+        "reported_features": reported,
+        "derived_features": derived,
+        "missing_fields": _missing_fields(reported, derived),
+        "can_confirm": usable_count > 0 and not (statuses & BLOCKING_STATUSES),
+    }
+
+
+def confirm_profile(draft):
+    validated = build_profile_draft(draft.get("candidates", []))
+    if not validated["can_confirm"]:
+        raise ValueError("Profile Draft is not eligible for confirmation")
+    validated["state"] = "confirmed"
+    validated["matching_started"] = False
+    return validated

--- a/chatbot-backend/test_app.py
+++ b/chatbot-backend/test_app.py
@@ -108,7 +108,7 @@ async def test_chat_with_history(client, mock_openai_with_intent):
 # --- Intent classification ---
 
 @pytest.mark.asyncio
-async def test_intent_clinical_returns_disease_select(client):
+async def test_intent_clinical_offers_the_research_demo_profile(client):
     with patch("app.client") as mock_client:
         mock_client.chat.completions.create.return_value = _mock_response("clinical")
         resp = await client.post(
@@ -118,12 +118,8 @@ async def test_intent_clinical_returns_disease_select(client):
         body = resp.json()
         assert body["intent"] == "clinical"
         assert body["reply"] == CLINICAL_PROMPT
-        assert body["ui"]["type"] == "disease_select"
-        diseases = body["ui"]["diseases"]
-        assert len(diseases) == 7
-        ids = [d["id"] for d in diseases]
-        assert "CKD" in ids
-        assert "NASH" in ids
+        assert body["ui"] == {"type": "demo_profile_start"}
+        assert "not medical advice" in body["reply"]
         mock_client.chat.completions.create.assert_called_once()
 
 

--- a/chatbot-backend/test_demo_profile.py
+++ b/chatbot-backend/test_demo_profile.py
@@ -1,0 +1,380 @@
+import csv
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app import app
+from demo_profile import (
+    INPUT_BOUNDS,
+    REFERENCE_SUPPORT,
+    ProfileRateLimiter,
+    build_profile_draft,
+    confirm_profile,
+    parse_feature_candidates,
+)
+
+
+def candidate(field, value, unit, source_text, operation="set"):
+    return {
+        "field": field,
+        "raw_value": value,
+        "raw_unit": unit,
+        "source_text": source_text,
+        "operation": operation,
+    }
+
+
+@pytest_asyncio.fixture
+async def api_client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+def test_height_and_weight_create_visible_bmi_before_explicit_confirmation():
+    draft = build_profile_draft(
+        [
+            candidate("height", 5.5, "ft", "height is 5.5 feet"),
+            candidate("weight", 150, "lb", "weight is 150 pounds"),
+        ]
+    )
+
+    assert draft["state"] == "draft"
+    assert draft["can_confirm"] is True
+    assert draft["reported_features"]["height"]["normalized_value"] == 167.64
+    assert draft["reported_features"]["height"]["source_text"] == "height is 5.5 feet"
+    assert draft["reported_features"]["weight"]["original_unit"] == "lb"
+    assert draft["derived_features"]["bmi"] == {
+        "label": "BMI",
+        "value": 24.2,
+        "unit": "kg/m²",
+        "domain": "body_composition",
+        "status": "valid",
+        "derived_from": ["height", "weight"],
+    }
+
+    confirmed = confirm_profile(draft)
+
+    assert confirmed["state"] == "confirmed"
+    assert confirmed["matching_started"] is False
+    assert confirmed["derived_features"]["bmi"]["value"] == 24.2
+
+
+def test_units_and_reference_support_are_deterministic_without_clamping():
+    draft = build_profile_draft(
+        [
+            candidate("height", 70, "in", "70 inches"),
+            candidate("weight", 400, "lb", "400 pounds"),
+            candidate("creatinine", 1.2, "mg/dL", "creatinine 1.2 mg/dL"),
+            candidate("hba1c", 6.5, "%", "HbA1c is 6.5%"),
+        ]
+    )
+
+    assert draft["reported_features"]["height"]["normalized_value"] == 177.8
+    assert draft["reported_features"]["weight"]["normalized_value"] == 181.44
+    assert draft["reported_features"]["weight"]["status"] == "outside_reference_support"
+    assert draft["reported_features"]["creatinine"]["normalized_value"] == 106.08
+    assert draft["reported_features"]["hba1c"]["normalized_value"] == 47.5
+    assert draft["can_confirm"] is True
+
+
+def test_compound_feet_and_inches_are_parsed_without_llm_arithmetic():
+    draft = build_profile_draft(
+        [candidate("height", "5 ft 6 in", "ft/in", "height is 5 ft 6 in")]
+    )
+
+    assert draft["reported_features"]["height"]["normalized_value"] == 167.64
+    assert draft["reported_features"]["height"]["original_value"] == "5 ft 6 in"
+
+
+def test_ambiguous_invalid_and_unsupported_candidates_remain_visible():
+    draft = build_profile_draft(
+        [
+            candidate("weight", 80, None, "weight 80"),
+            candidate("age", -4, None, "age negative four"),
+            candidate("favorite_color", "blue", None, "favorite color blue"),
+        ]
+    )
+
+    assert draft["reported_features"]["weight"]["status"] == "ambiguous"
+    assert draft["reported_features"]["age"]["status"] == "out_of_range"
+    assert draft["reported_features"]["favorite_color"]["status"] == "unsupported"
+    assert draft["can_confirm"] is False
+    assert "height" in draft["missing_fields"]
+    assert "bmi" not in draft["derived_features"]
+
+
+def test_llm_unit_must_be_supported_by_the_candidate_source_text():
+    invented = build_profile_draft(
+        [candidate("weight", 80, "kg", "weight 80")]
+    )
+    explicit = build_profile_draft(
+        [candidate("weight", 180, "lb", "weight is 180 pounds")]
+    )
+
+    assert invented["reported_features"]["weight"]["status"] == "ambiguous"
+    assert "not explicit" in invented["reported_features"]["weight"]["message"]
+    assert explicit["reported_features"]["weight"]["status"] == "valid"
+
+
+def test_schema_assigns_only_unambiguous_units_when_llm_leaves_them_empty():
+    draft = build_profile_draft(
+        [
+            candidate("age", 55, None, "I am 55"),
+            candidate("bmi", 24.5, None, "BMI 24.5"),
+            candidate("blood_pressure", "135/85", None, "blood pressure 135/85"),
+        ]
+    )
+
+    assert draft["reported_features"]["age"]["normalized_unit"] == "years"
+    assert draft["reported_features"]["bmi"]["normalized_unit"] == "kg/m²"
+    assert draft["reported_features"]["sbp"]["normalized_unit"] == "mmHg"
+
+
+def test_llm_cannot_invent_an_implicit_field_unit():
+    draft = build_profile_draft(
+        [candidate("bmi", 30, "kg/m2", "BMI 30")]
+    )
+
+    assert draft["reported_features"]["bmi"]["status"] == "ambiguous"
+
+
+def test_blood_pressure_and_waist_hip_components_are_visible_before_derivation():
+    draft = build_profile_draft(
+        [
+            candidate("blood_pressure", "135/85", None, "blood pressure 135/85"),
+            candidate("waist", 32, "in", "waist 32 inches"),
+            candidate("hip", 40, "in", "hip 40 inches"),
+        ]
+    )
+
+    assert draft["reported_features"]["sbp"]["normalized_value"] == 135
+    assert draft["reported_features"]["dbp"]["normalized_value"] == 85
+    assert draft["reported_features"]["sbp"]["source_text"] == "blood pressure 135/85"
+    assert draft["derived_features"]["waist_to_hip_ratio"]["value"] == 0.8
+
+
+def test_conflict_requires_an_explicit_correction_and_keeps_candidate_history():
+    first = candidate("age", 55, None, "I am 55")
+    conflicting = candidate("age", 56, None, "age 56")
+    draft = build_profile_draft([first, conflicting])
+
+    assert draft["reported_features"]["age"]["status"] == "conflicting"
+    assert draft["reported_features"]["age"]["alternatives"] == [55, 56]
+    assert draft["can_confirm"] is False
+
+    corrected = build_profile_draft(
+        [first, conflicting, candidate("age", 57, None, "Correction: 57", "correct")]
+    )
+
+    assert corrected["reported_features"]["age"]["status"] == "valid"
+    assert corrected["reported_features"]["age"]["normalized_value"] == 57
+    assert [item["source_text"] for item in corrected["candidates"]] == [
+        "I am 55",
+        "age 56",
+        "Correction: 57",
+    ]
+    assert corrected["reported_features"]["age"]["source_history"][0]["source_text"] == "I am 55"
+    assert corrected["reported_features"]["age"]["source_history"][-1]["source_text"] == "Correction: 57"
+
+
+def test_reported_bmi_must_agree_with_the_calculated_value():
+    draft = build_profile_draft(
+        [
+            candidate("height", 180, "cm", "height 180 cm"),
+            candidate("weight", 81, "kg", "weight 81 kg"),
+            candidate("bmi", 30, None, "BMI 30"),
+        ]
+    )
+
+    assert draft["derived_features"]["bmi"]["value"] == 25.0
+    assert draft["reported_features"]["bmi"]["status"] == "conflicting"
+    assert draft["reported_features"]["bmi"]["calculated_value"] == 25.0
+    assert draft["can_confirm"] is False
+
+
+def test_reported_bmi_mismatch_can_be_explicitly_confirmed():
+    candidates = [
+        candidate("height", 180, "cm", "height 180 cm"),
+        candidate("weight", 81, "kg", "weight 81 kg"),
+        candidate("bmi", 30, "kg/m2", "BMI 30 kg/m2"),
+        candidate("bmi", 30, None, "Edited in review: BMI", "correct"),
+    ]
+
+    draft = build_profile_draft(candidates)
+
+    assert draft["reported_features"]["bmi"]["status"] == "valid"
+    assert draft["reported_features"]["bmi"]["calculated_value"] == 25.0
+    assert draft["reported_features"]["bmi"]["mismatch_acknowledged"] is True
+    assert draft["can_confirm"] is True
+
+
+def test_implausible_derived_bmi_is_visible_and_blocks_confirmation():
+    draft = build_profile_draft(
+        [
+            candidate("height", 50, "cm", "height 50 cm"),
+            candidate("weight", 500, "kg", "weight 500 kg"),
+        ]
+    )
+
+    assert draft["derived_features"]["bmi"]["value"] == 2000.0
+    assert draft["derived_features"]["bmi"]["status"] == "out_of_range"
+    assert draft["can_confirm"] is False
+
+
+def test_categories_are_canonicalized_but_optional_sex_is_never_inferred():
+    draft = build_profile_draft(
+        [
+            candidate("smoking status", "Former smoker", None, "former smoker"),
+            candidate("alcohol frequency", "once or twice a week", None, "once or twice a week"),
+            candidate("family history", "yes", None, "family history yes"),
+        ]
+    )
+
+    assert draft["reported_features"]["smoking_status"]["normalized_value"] == "former"
+    assert draft["reported_features"]["alcohol_frequency"]["normalized_value"] == "one_to_two_per_week"
+    assert draft["reported_features"]["affected_relative"]["normalized_value"] is True
+    assert "sex" not in draft["reported_features"]
+
+
+def test_remove_operation_clears_only_the_named_reported_feature():
+    draft = build_profile_draft(
+        [
+            candidate("age", 55, None, "age 55"),
+            candidate("weight", 80, "kg", "weight 80 kg"),
+            candidate("age", None, None, "remove age", "remove"),
+        ]
+    )
+
+    assert "age" not in draft["reported_features"]
+    assert draft["reported_features"]["weight"]["normalized_value"] == 80
+
+
+def test_profile_rate_limit_is_deterministic_per_client_window():
+    limiter = ProfileRateLimiter(limit=2, window_seconds=60)
+
+    assert limiter.allow("client-a", now=0) is True
+    assert limiter.allow("client-a", now=1) is True
+    assert limiter.allow("client-a", now=2) is False
+    assert limiter.allow("client-b", now=2) is True
+    assert limiter.allow("client-a", now=61) is True
+
+
+def test_operational_input_bounds_contain_the_current_reference_support():
+    source_fields = {
+        "age": "age_recruit",
+        "height": "height",
+        "weight": "weight",
+        "bmi": "BMI",
+        "waist": "waist",
+        "hip": "hip",
+        "dbp": "DBP",
+        "sbp": "SBP",
+        "creatinine": "creatinine",
+        "hba1c": "HbA1c",
+    }
+    source = Path(__file__).parent / "data" / "fibrotic_patient_embeddings.csv"
+    with source.open(newline="") as file:
+        rows = list(csv.DictReader(file))
+
+    for field, source_field in source_fields.items():
+        values = [float(row[source_field]) for row in rows if row[source_field]]
+        support_min, support_max = REFERENCE_SUPPORT[field]
+        input_min, input_max = INPUT_BOUNDS[field]
+        assert min(values) == support_min
+        assert max(values) == support_max
+        assert input_min <= support_min <= support_max <= input_max
+
+
+@pytest.mark.asyncio
+async def test_extraction_returns_candidates_only_and_preserves_exact_source_text(api_client):
+    response_json = {
+        "candidates": [
+            candidate("height", 180, "cm", "height is 180 cm"),
+            candidate("weight", 81, "kg", "weight is 81 kg"),
+        ]
+    }
+    with patch("app.client") as llm:
+        llm.chat.completions.create.return_value.choices[0].message.content = json.dumps(
+            response_json
+        )
+        response = await api_client.post(
+            "/profile/extract",
+            json={"message": "My synthetic profile: height is 180 cm and weight is 81 kg"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert list(body) == ["candidates"]
+    assert body["candidates"][0]["source_text"] == "height is 180 cm"
+    assert "confirmed" not in json.dumps(body).lower()
+    assert "match" not in json.dumps(body).lower()
+
+
+@pytest.mark.asyncio
+async def test_profile_contract_validates_then_requires_a_separate_confirm_call(api_client):
+    candidates = [
+        candidate("height", 180, "cm", "height 180 cm"),
+        candidate("weight", 81, "kg", "weight 81 kg"),
+    ]
+
+    validation = await api_client.post("/profile/validate", json={"candidates": candidates})
+    assert validation.status_code == 200
+    draft = validation.json()
+    assert draft["state"] == "draft"
+    assert draft["derived_features"]["bmi"]["value"] == 25.0
+    assert "matching_started" not in draft
+
+    confirmation = await api_client.post("/profile/confirm", json={"draft": draft})
+    assert confirmation.status_code == 200
+    assert confirmation.json()["state"] == "confirmed"
+    assert confirmation.json()["matching_started"] is False
+
+
+@pytest.mark.asyncio
+async def test_confirm_revalidates_candidates_and_rejects_a_tampered_draft(api_client):
+    draft = build_profile_draft([candidate("weight", 80, None, "weight 80")])
+    draft["can_confirm"] = True
+    draft["reported_features"]["weight"]["status"] = "valid"
+
+    response = await api_client.post("/profile/confirm", json={"draft": draft})
+
+    assert response.status_code == 409
+    assert "not eligible" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_extraction_has_bounded_input(api_client):
+    oversized = await api_client.post(
+        "/profile/extract",
+        json={"message": "x" * 2001},
+    )
+
+    assert oversized.status_code == 422
+
+
+def test_invalid_candidate_operation_is_blocking_not_reinterpreted_as_set():
+    draft = build_profile_draft(
+        [candidate("age", 55, "years", "age 55", "invented-operation")]
+    )
+
+    assert draft["reported_features"]["age"]["status"] == "ambiguous"
+    assert draft["can_confirm"] is False
+
+
+def test_extraction_contract_rejects_markdown_wrapped_json():
+    with pytest.raises(ValueError, match="valid JSON"):
+        parse_feature_candidates("age 55", '```json\n{"candidates": []}\n```')
+
+
+@pytest.mark.asyncio
+async def test_validation_contract_rejects_an_unknown_operation(api_client):
+    invalid = candidate("age", 55, "years", "age 55", "invented-operation")
+
+    response = await api_client.post("/profile/validate", json={"candidates": [invalid]})
+
+    assert response.status_code == 422

--- a/chatbot/chatbot-include.html
+++ b/chatbot/chatbot-include.html
@@ -1,3 +1,4 @@
 <link rel="stylesheet" href="/chatbot/chatbot.css">
 <script src="/chatbot/embedding-demo.js?v=56c5f57a" defer></script>
-<script src="/chatbot/chatbot.js?v=cd4b2571" defer></script>
+<script src="/chatbot/profile-session.js?v=issue25" defer></script>
+<script src="/chatbot/chatbot.js?v=issue25" defer></script>

--- a/chatbot/chatbot.css
+++ b/chatbot/chatbot.css
@@ -276,6 +276,202 @@
   background: #f4f8fd;
 }
 
+.chatbot-profile-starter {
+  max-width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #9fc7b3;
+  background: #f2faf6;
+}
+
+.chatbot-profile-review,
+.chatbot-profile-confirmed {
+  align-self: stretch;
+  max-width: 100%;
+  padding: 0.8rem;
+  border: 1px solid #bfd0e8;
+  background: #f8fafc;
+}
+
+.chatbot-profile-title {
+  color: #173f73;
+  font-size: 0.9rem;
+  font-weight: 750;
+}
+
+.chatbot-profile-notice {
+  margin: 0.3rem 0 0.65rem;
+  color: #495057;
+  font-size: 0.76rem;
+  line-height: 1.4;
+}
+
+.chatbot-profile-field {
+  padding: 0.55rem 0;
+  border-top: 1px solid #e2e8f0;
+}
+
+.chatbot-profile-field-heading,
+.chatbot-profile-edit,
+.chatbot-profile-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.chatbot-profile-field-heading {
+  justify-content: space-between;
+  margin-bottom: 0.3rem;
+}
+
+.chatbot-profile-field-label {
+  color: #273444;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.chatbot-profile-status {
+  border-radius: 999px;
+  padding: 0.12rem 0.4rem;
+  font-size: 0.62rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.status-valid {
+  background: #dff3e7;
+  color: #17633a;
+}
+
+.status-outside_reference_support {
+  background: #fff0c7;
+  color: #765300;
+}
+
+.status-ambiguous,
+.status-out_of_range,
+.status-conflicting {
+  background: #fde2e2;
+  color: #8a2424;
+}
+
+.status-unsupported {
+  background: #e9ecef;
+  color: #5c636a;
+}
+
+.chatbot-profile-input {
+  min-width: 0;
+  flex: 1;
+  padding: 0.35rem 0.48rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  background: #fff;
+  color: #1f2937;
+  font: inherit;
+  font-size: 0.78rem;
+}
+
+.chatbot-profile-input:focus {
+  border-color: #2c5aa0;
+  outline: 2px solid rgba(44, 90, 160, 0.15);
+}
+
+.chatbot-profile-unit {
+  color: #5f6b78;
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
+.chatbot-profile-source,
+.chatbot-profile-source-history,
+.chatbot-profile-field-message,
+.chatbot-profile-conflicts,
+.chatbot-profile-action-status,
+.chatbot-profile-confirmed-count {
+  margin-top: 0.28rem;
+  color: #66717d;
+  font-size: 0.68rem;
+  line-height: 1.35;
+}
+
+.chatbot-profile-field-message {
+  color: #8a2424;
+}
+
+.chatbot-profile-conflicts {
+  color: #7b3030;
+}
+
+.chatbot-profile-source-history {
+  color: #536579;
+}
+
+.chatbot-profile-subtitle {
+  margin-top: 0.6rem;
+  color: #273444;
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.chatbot-profile-derived {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.25rem;
+  padding: 0.35rem 0.45rem;
+  border-left: 3px solid #2c5aa0;
+  background: #edf4fc;
+  color: #334155;
+  font-size: 0.72rem;
+}
+
+.chatbot-profile-derived .chatbot-profile-field-message {
+  flex-basis: 100%;
+}
+
+.chatbot-profile-actions {
+  flex-wrap: wrap;
+  margin-top: 0.7rem;
+}
+
+.chatbot-profile-primary,
+.chatbot-profile-secondary,
+.chatbot-profile-link {
+  border-radius: 7px;
+  padding: 0.42rem 0.65rem;
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.chatbot-profile-primary {
+  border: 1px solid #2c5aa0;
+  background: #2c5aa0;
+  color: #fff;
+}
+
+.chatbot-profile-secondary {
+  border: 1px solid #2c5aa0;
+  background: #fff;
+  color: #2c5aa0;
+}
+
+.chatbot-profile-link {
+  border: 0;
+  background: transparent;
+  color: #5c6773;
+  text-decoration: underline;
+}
+
+.chatbot-profile-primary:disabled,
+.chatbot-profile-secondary:disabled,
+.chatbot-profile-link:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
 .chatbot-demo-label {
   color: #2c5aa0;
   font-size: 0.74rem;
@@ -652,6 +848,52 @@
 .quarto-dark .chatbot-demo-card {
   border-color: #3d5f8d;
   background: #26384f;
+}
+
+.quarto-dark .chatbot-profile-starter,
+.quarto-dark .chatbot-profile-review,
+.quarto-dark .chatbot-profile-confirmed {
+  border-color: #3d5f8d;
+  background: #26323f;
+}
+
+.quarto-dark .chatbot-profile-title,
+.quarto-dark .chatbot-profile-field-label,
+.quarto-dark .chatbot-profile-subtitle {
+  color: #e2e8f0;
+}
+
+.quarto-dark .chatbot-profile-notice,
+.quarto-dark .chatbot-profile-source,
+.quarto-dark .chatbot-profile-action-status,
+.quarto-dark .chatbot-profile-confirmed-count,
+.quarto-dark .chatbot-profile-unit {
+  color: #b9c2cc;
+}
+
+.quarto-dark .chatbot-profile-field {
+  border-top-color: #44505d;
+}
+
+.quarto-dark .chatbot-profile-input {
+  border-color: #56616d;
+  background: #1f252b;
+  color: #edf2f7;
+}
+
+.quarto-dark .chatbot-profile-derived {
+  background: #223a55;
+  color: #dbeafe;
+}
+
+.quarto-dark .chatbot-profile-secondary {
+  border-color: #72a5e5;
+  background: transparent;
+  color: #9fc5f5;
+}
+
+.quarto-dark .chatbot-profile-link {
+  color: #c6d2df;
 }
 
 .quarto-dark .chatbot-demo-label {

--- a/chatbot/chatbot.js
+++ b/chatbot/chatbot.js
@@ -2,8 +2,33 @@
   "use strict";
 
   var DEMO = window.ALIGATEHR_EMBEDDING_DEMO;
+  var PROFILE = window.ALIGATEHR_PROFILE_SESSION;
   var API_URL = DEMO.resolveApiUrl(window.location, window.ALIGATEHR_API_URL);
   var STORAGE_PREFIX = "aligatehr-chatbot-";
+  var profileSession = PROFILE.create(sessionStorage);
+  var PROFILE_CHOICES = {
+    sex: [
+      ["female", "Female"],
+      ["male", "Male"],
+    ],
+    smoking_status: [
+      ["never", "Never"],
+      ["former", "Former"],
+      ["current", "Current"],
+    ],
+    alcohol_frequency: [
+      ["never", "Never"],
+      ["special_occasions", "Special occasions only"],
+      ["one_to_three_per_month", "1–3 times a month"],
+      ["one_to_two_per_week", "1–2 times a week"],
+      ["three_to_four_per_week", "3–4 times a week"],
+      ["daily_or_almost_daily", "Daily or almost daily"],
+    ],
+    affected_relative: [
+      ["true", "Yes"],
+      ["false", "No"],
+    ],
+  };
 
   var ICON_EXPAND = '<svg viewBox="0 0 24 24"><path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/></svg>';
   var ICON_COLLAPSE = '<svg viewBox="0 0 24 24"><path d="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z"/></svg>';
@@ -11,6 +36,7 @@
   var history = [];
   var busy = false;
   var lastAssessedDisease = null;
+  var profileCardCounter = 0;
 
   // ── Build DOM ──
 
@@ -122,9 +148,12 @@
       "assistant",
       "Hello! I'm the ALIGATEHR-Gen chatbot. I can help you understand our paper's methodology, results, and clinical implications. What would you like to know?"
     );
+    renderProfileStarterCard();
     renderPresetDemoCard();
   }
+  profileCardCounter = messagesEl.querySelectorAll(".chatbot-profile-review").length;
   resetPresetDemoCards();
+  updateProfileInputState();
 
   // ── Events ──
 
@@ -165,8 +194,14 @@
   sendBtn.addEventListener("click", send);
 
   messagesEl.addEventListener("click", function (event) {
-    var button = event.target.closest('[data-chatbot-action="preset-embedding-demo"]');
-    if (button) startPresetDemo(button);
+    var button = event.target.closest("[data-chatbot-action]");
+    if (!button) return;
+    var action = button.getAttribute("data-chatbot-action");
+    if (action === "preset-embedding-demo") startPresetDemo(button);
+    if (action === "start-demo-profile") startDemoProfile();
+    if (action === "save-profile-edits") saveProfileEdits(button);
+    if (action === "confirm-demo-profile") confirmDemoProfile(button);
+    if (action === "start-over-demo-profile") startOverDemoProfile();
   });
 
   // Auto-resize textarea
@@ -177,8 +212,9 @@
 
   // ── Core logic ──
 
-  function addMessage(role, text) {
+  function addMessage(role, text, scope) {
     var msg = createEl("div", "chatbot-msg chatbot-msg-" + role);
+    if (scope) msg.setAttribute("data-profile-scope", scope);
     if (role === "assistant") {
       msg.innerHTML = renderMarkdown(text);
     } else {
@@ -194,6 +230,27 @@
     messagesEl.appendChild(el);
     messagesEl.scrollTop = messagesEl.scrollHeight;
     saveState();
+  }
+
+  function renderProfileStarterCard() {
+    if (messagesEl.querySelector('[data-chatbot-action="start-demo-profile"]')) return;
+    var card = createEl(
+      "div",
+      "chatbot-msg chatbot-msg-assistant chatbot-profile-starter",
+    );
+    var label = createEl("div", "chatbot-demo-label");
+    label.textContent = "Research Demo Profile";
+    var copy = createEl("p", "chatbot-demo-copy");
+    copy.textContent =
+      "Build an editable synthetic or de-identified profile. Values are reviewed " +
+      "before confirmation and never start matching automatically.";
+    var button = createEl("button", "chatbot-demo-button", {
+      type: "button",
+      "data-chatbot-action": "start-demo-profile",
+    });
+    button.textContent = "Build Demo Profile";
+    card.append(label, copy, button);
+    addRawElement(card);
   }
 
   function renderPresetDemoCard() {
@@ -280,6 +337,390 @@
       });
   }
 
+  function updateProfileInputState() {
+    var phase = profileSession.getState().phase;
+    var startButton = messagesEl.querySelector(
+      '[data-chatbot-action="start-demo-profile"]',
+    );
+    if (startButton) {
+      startButton.disabled = phase !== "inactive";
+      startButton.textContent =
+        phase === "draft"
+          ? "Profile Draft active"
+          : phase === "confirmed"
+            ? "Profile confirmed"
+            : "Build Demo Profile";
+    }
+    input.placeholder =
+      phase === "draft"
+        ? "Add synthetic profile details or a correction…"
+        : "Ask a question…";
+  }
+
+  function startDemoProfile() {
+    if (profileSession.getState().phase === "draft") {
+      input.focus();
+      return;
+    }
+    profileSession.start();
+    addMessage(
+      "assistant",
+      "**Research demo only — not medical advice, diagnosis, or a personal outcome prediction.** " +
+        "Use a synthetic or sufficiently de-identified profile. Do not enter names, " +
+        "exact birth dates, addresses, patient IDs, or real medical records. You can " +
+        "provide details in one message or across several messages.",
+      "active",
+    );
+    updateProfileInputState();
+    input.focus();
+  }
+
+  function validateProfileCandidates(statusEl) {
+    var candidates = profileSession.getState().candidates;
+    if (statusEl) statusEl.textContent = "Validating fields and units…";
+    return fetch(API_URL + "/profile/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ candidates: candidates }),
+    })
+      .then(function (response) {
+        if (!response.ok) throw new Error("API returned " + response.status);
+        return response.json();
+      })
+      .then(function (draft) {
+        profileSession.applyDraft(draft);
+        renderProfileDraft(draft);
+        return draft;
+      });
+  }
+
+  function sendProfileMessage(text) {
+    addMessage("user", text, "active");
+    history.push({ role: "user", content: text, scope: "profile" });
+    input.value = "";
+    input.style.height = "auto";
+    busy = true;
+    sendBtn.disabled = true;
+    var typing = showTyping();
+    typing.setAttribute("data-profile-scope", "active");
+
+    fetch(API_URL + "/profile/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: text }),
+    })
+      .then(function (response) {
+        if (!response.ok) {
+          return response.json().catch(function () { return {}; }).then(function (body) {
+            throw new Error(body.detail || "API returned " + response.status);
+          });
+        }
+        return response.json();
+      })
+      .then(function (data) {
+        profileSession.appendCandidates(data.candidates || []);
+        return validateProfileCandidates();
+      })
+      .then(function (draft) {
+        typing.remove();
+        var count = Object.keys(draft.reported_features || {}).length;
+        var reply = count
+          ? "I created an editable Profile Draft. Review every value and status below before confirming."
+          : "I could not identify a supported field yet. Add an easy-to-know measurement such as age, height, weight, or blood pressure.";
+        addMessage("assistant", reply, "active");
+        history.push({ role: "assistant", content: reply, scope: "profile" });
+      })
+      .catch(function (error) {
+        typing.remove();
+        addMessage(
+          "assistant",
+          "I could not update the Profile Draft. " + error.message + " Please correct the message or try again.",
+          "active",
+        );
+      })
+      .finally(function () {
+        busy = false;
+        sendBtn.disabled = false;
+        saveState();
+      });
+  }
+
+  function statusLabel(status) {
+    return {
+      valid: "Valid",
+      ambiguous: "Needs clarification",
+      out_of_range: "Outside accepted input range",
+      outside_reference_support: "Outside reference support",
+      unsupported: "Unsupported for this demo",
+      conflicting: "Conflicting values",
+    }[status] || status;
+  }
+
+  function renderProfileDraft(draft) {
+    profileCardCounter += 1;
+    var cardId = "profile-review-" + profileCardCounter;
+    var oldCards = messagesEl.querySelectorAll(".chatbot-profile-review[data-profile-current='1']");
+    oldCards.forEach(function (card) {
+      card.remove();
+    });
+
+    var card = createEl(
+      "div",
+      "chatbot-msg chatbot-msg-assistant chatbot-profile-review",
+      { "data-profile-scope": "active", "data-profile-current": "1" },
+    );
+    var title = createEl("div", "chatbot-profile-title");
+    title.textContent = "Profile Draft — review required";
+    card.appendChild(title);
+
+    var notice = createEl("p", "chatbot-profile-notice");
+    notice.textContent =
+      "Demo/research comparison only. No matching or personal prediction has started.";
+    card.appendChild(notice);
+
+    var features = draft.reported_features || {};
+    Object.keys(features).forEach(function (field) {
+      var feature = features[field];
+      var row = createEl("div", "chatbot-profile-field");
+      row.setAttribute("data-profile-field", field);
+      var heading = createEl("div", "chatbot-profile-field-heading");
+      var label = createEl("label", "chatbot-profile-field-label");
+      label.textContent = feature.label;
+      label.setAttribute("for", cardId + "-" + field);
+      var badge = createEl(
+        "span",
+        "chatbot-profile-status status-" + feature.status,
+      );
+      badge.textContent = statusLabel(feature.status);
+      heading.append(label, badge);
+
+      var edit = createEl("div", "chatbot-profile-edit");
+      var inputEl;
+      if (PROFILE_CHOICES[field]) {
+        inputEl = createEl("select", "chatbot-profile-input", {
+          id: cardId + "-" + field,
+          name: field,
+        });
+        var promptOption = createEl("option");
+        promptOption.value = "";
+        promptOption.textContent = "Choose a value";
+        inputEl.appendChild(promptOption);
+        PROFILE_CHOICES[field].forEach(function (choice) {
+          var option = createEl("option");
+          option.value = choice[0];
+          option.textContent = choice[1];
+          inputEl.appendChild(option);
+        });
+        if (feature.normalized_value != null) {
+          inputEl.value = String(feature.normalized_value);
+        }
+      } else {
+        inputEl = createEl("input", "chatbot-profile-input", {
+          id: cardId + "-" + field,
+          name: field,
+          type: "text",
+          value:
+            feature.normalized_value == null
+              ? String(feature.original_value == null ? "" : feature.original_value)
+              : String(feature.normalized_value),
+        });
+      }
+      if (feature.status === "unsupported") inputEl.disabled = true;
+      edit.appendChild(inputEl);
+      if (feature.normalized_unit) {
+        var unit = createEl("span", "chatbot-profile-unit");
+        unit.textContent = feature.normalized_unit;
+        edit.appendChild(unit);
+      }
+
+      var source = createEl("div", "chatbot-profile-source");
+      source.textContent =
+        "Source: “" + feature.source_text + "”" +
+        (feature.original_unit ? " (original unit: " + feature.original_unit + ")" : "");
+      row.append(heading, edit, source);
+      if (feature.message) {
+        var message = createEl("div", "chatbot-profile-field-message");
+        message.textContent = feature.message;
+        row.appendChild(message);
+      }
+      if (feature.alternatives) {
+        var alternatives = createEl("div", "chatbot-profile-conflicts");
+        alternatives.textContent = "Conflicting values: " + feature.alternatives.join("; ");
+        row.appendChild(alternatives);
+      }
+      if (feature.source_texts) {
+        var sources = createEl("div", "chatbot-profile-conflicts");
+        sources.textContent =
+          "Sources: “" + feature.source_texts.join("”; “") + "”";
+        row.appendChild(sources);
+      }
+      if (feature.source_history && feature.source_history.length > 1) {
+        var historyCopy = createEl("div", "chatbot-profile-source-history");
+        historyCopy.textContent =
+          "Source history: " +
+          feature.source_history.map(function (entry) {
+            return (
+              "“" + entry.source_text + "”" +
+              (entry.original_unit ? " (" + entry.original_unit + ")" : "")
+            );
+          }).join("; ");
+        row.appendChild(historyCopy);
+      }
+      card.appendChild(row);
+    });
+
+    var derived = draft.derived_features || {};
+    if (Object.keys(derived).length) {
+      var derivedTitle = createEl("div", "chatbot-profile-subtitle");
+      derivedTitle.textContent = "Derived Match Features";
+      card.appendChild(derivedTitle);
+      Object.keys(derived).forEach(function (field) {
+        var feature = derived[field];
+        var item = createEl("div", "chatbot-profile-derived");
+        var derivedCopy = createEl("span", "chatbot-profile-derived-copy");
+        derivedCopy.textContent =
+          feature.label + ": " + feature.value + " " + feature.unit +
+          " (from " + feature.derived_from.join(" + ") + ")";
+        var derivedBadge = createEl(
+          "span",
+          "chatbot-profile-status status-" + feature.status,
+        );
+        derivedBadge.textContent = statusLabel(feature.status);
+        item.append(derivedCopy, derivedBadge);
+        if (feature.message) {
+          var derivedMessage = createEl("div", "chatbot-profile-field-message");
+          derivedMessage.textContent = feature.message;
+          item.appendChild(derivedMessage);
+        }
+        card.appendChild(item);
+      });
+    }
+
+    var actions = createEl("div", "chatbot-profile-actions");
+    var saveButton = createEl("button", "chatbot-profile-secondary", {
+      type: "button",
+      "data-chatbot-action": "save-profile-edits",
+    });
+    saveButton.textContent = "Save corrections";
+    var confirmButton = createEl("button", "chatbot-profile-primary", {
+      type: "button",
+      "data-chatbot-action": "confirm-demo-profile",
+    });
+    confirmButton.textContent = "Confirm Demo Profile";
+    confirmButton.disabled = !draft.can_confirm;
+    var startOverButton = createEl("button", "chatbot-profile-link", {
+      type: "button",
+      "data-chatbot-action": "start-over-demo-profile",
+    });
+    startOverButton.textContent = "Start Over";
+    actions.append(saveButton, confirmButton, startOverButton);
+    card.appendChild(actions);
+
+    var status = createEl("div", "chatbot-profile-action-status", {
+      "aria-live": "polite",
+    });
+    if (!draft.can_confirm) {
+      status.textContent = "Resolve fields marked for clarification or conflict before confirming.";
+    }
+    card.appendChild(status);
+    addRawElement(card);
+  }
+
+  function saveProfileEdits(button) {
+    var card = button.closest(".chatbot-profile-review");
+    var state = profileSession.getState();
+    if (!card || state.phase !== "draft" || !state.draft) return;
+    var edits = {};
+    card.querySelectorAll("[data-profile-field] input, [data-profile-field] select").forEach(function (fieldInput) {
+      edits[fieldInput.name] = fieldInput.value.trim();
+    });
+    var corrections = PROFILE.createCorrections(state.draft, edits);
+    var status = card.querySelector(".chatbot-profile-action-status");
+    if (!corrections.length) {
+      status.textContent = "No changed values to save.";
+      return;
+    }
+    button.disabled = true;
+    profileSession.appendCandidates(corrections);
+    validateProfileCandidates(status).catch(function (error) {
+      button.disabled = false;
+      status.textContent = "Could not save corrections. " + error.message;
+    });
+  }
+
+  function confirmDemoProfile(button) {
+    var state = profileSession.getState();
+    if (state.phase !== "draft" || !state.draft || !state.draft.can_confirm) return;
+    var card = button.closest(".chatbot-profile-review");
+    var status = card.querySelector(".chatbot-profile-action-status");
+    button.disabled = true;
+    status.textContent = "Confirming the reviewed Profile Draft…";
+    fetch(API_URL + "/profile/confirm", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ draft: state.draft }),
+    })
+      .then(function (response) {
+        if (!response.ok) throw new Error("API returned " + response.status);
+        return response.json();
+      })
+      .then(function (confirmed) {
+        profileSession.confirm(confirmed);
+        card.setAttribute("data-profile-current", "0");
+        card.querySelectorAll("input, button").forEach(function (control) {
+          control.disabled = true;
+        });
+        renderConfirmedProfile(confirmed);
+        updateProfileInputState();
+      })
+      .catch(function (error) {
+        button.disabled = false;
+        status.textContent = "Could not confirm the profile. " + error.message;
+      });
+  }
+
+  function renderConfirmedProfile(confirmed) {
+    var card = createEl(
+      "div",
+      "chatbot-msg chatbot-msg-assistant chatbot-profile-confirmed",
+      { "data-profile-scope": "active" },
+    );
+    var title = createEl("div", "chatbot-profile-title");
+    title.textContent = "Confirmed Profile";
+    var copy = createEl("p", "chatbot-profile-notice");
+    copy.textContent =
+      "Your reviewed Demo Profile is confirmed for this tab. No cohort matching or " +
+      "risk endpoint was called, and this is not medical advice or a personal prediction.";
+    var count = createEl("div", "chatbot-profile-confirmed-count");
+    count.textContent =
+      Object.keys(confirmed.reported_features || {}).length +
+      " reported features; " +
+      Object.keys(confirmed.derived_features || {}).length +
+      " derived features.";
+    var startOver = createEl("button", "chatbot-profile-link", {
+      type: "button",
+      "data-chatbot-action": "start-over-demo-profile",
+    });
+    startOver.textContent = "Start Over";
+    card.append(title, copy, count, startOver);
+    addRawElement(card);
+  }
+
+  function startOverDemoProfile() {
+    profileSession.reset();
+    history = history.filter(function (item) { return item.scope !== "profile"; });
+    messagesEl.querySelectorAll("[data-profile-scope]").forEach(function (element) {
+      element.remove();
+    });
+    updateProfileInputState();
+    addMessage(
+      "assistant",
+      "The Demo Profile session was cleared. Your unrelated chatbot conversation remains available.",
+    );
+    renderProfileStarterCard();
+    saveState();
+  }
+
   function showTyping() {
     var el = createEl("div", "chatbot-typing");
     for (var i = 0; i < 3; i++) {
@@ -294,6 +735,11 @@
     var text = input.value.trim();
     if (!text || busy) return;
 
+    if (profileSession.getState().phase === "draft") {
+      sendProfileMessage(text);
+      return;
+    }
+
     addMessage("user", text);
     history.push({ role: "user", content: text });
 
@@ -304,7 +750,13 @@
 
     var typing = showTyping();
 
-    var chatBody = { message: text, history: history.slice(0, -1) };
+    var chatBody = {
+      message: text,
+      history: history
+        .slice(0, -1)
+        .filter(function (item) { return item.scope !== "profile"; })
+        .map(function (item) { return { role: item.role, content: item.content }; }),
+    };
     if (lastAssessedDisease) {
       chatBody.assessed_disease = lastAssessedDisease;
     }
@@ -326,6 +778,9 @@
 
         if (data.ui && data.ui.type === "disease_select") {
           renderDiseaseSelect(data.ui.diseases);
+        }
+        if (data.ui && data.ui.type === "demo_profile_start") {
+          renderProfileStarterCard();
         }
         if (data.ui && data.ui.type === "pathway_enrichment") {
           renderPathwayEnrichment(data.ui);

--- a/chatbot/profile-session.js
+++ b/chatbot/profile-session.js
@@ -1,0 +1,134 @@
+(function (root, factory) {
+  var api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  if (root) root.ALIGATEHR_PROFILE_SESSION = api;
+})(typeof window !== "undefined" ? window : globalThis, function () {
+  "use strict";
+
+  var STORAGE_KEY = "aligatehr-demo-profile-session";
+
+  function initialState() {
+    return {
+      phase: "inactive",
+      candidates: [],
+      draft: null,
+      confirmed: null,
+    };
+  }
+
+  function restore(storage) {
+    var raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return initialState();
+    try {
+      var parsed = JSON.parse(raw);
+      if (
+        !parsed ||
+        !["inactive", "draft", "confirmed"].includes(parsed.phase) ||
+        !Array.isArray(parsed.candidates)
+      ) {
+        throw new Error("invalid profile session");
+      }
+      return parsed;
+    } catch (error) {
+      storage.removeItem(STORAGE_KEY);
+      return initialState();
+    }
+  }
+
+  function create(storage) {
+    var state = restore(storage);
+
+    function save() {
+      storage.setItem(STORAGE_KEY, JSON.stringify(state));
+    }
+
+    return {
+      getState: function () {
+        return state;
+      },
+      start: function () {
+        state = {
+          phase: "draft",
+          candidates: [],
+          draft: null,
+          confirmed: null,
+        };
+        save();
+        return state;
+      },
+      appendCandidates: function (candidates) {
+        if (state.phase !== "draft") {
+          throw new Error("Feature Candidates require an active Profile Draft");
+        }
+        state.candidates = state.candidates.concat(candidates);
+        save();
+        return state;
+      },
+      applyDraft: function (draft) {
+        if (state.phase !== "draft" || !draft || draft.state !== "draft") {
+          throw new Error("Only a Profile Draft can be applied");
+        }
+        state.draft = draft;
+        save();
+        return state;
+      },
+      confirm: function (confirmed) {
+        if (
+          state.phase !== "draft" ||
+          !confirmed ||
+          confirmed.state !== "confirmed" ||
+          confirmed.matching_started !== false
+        ) {
+          throw new Error("Confirmation requires an explicit confirmed response");
+        }
+        state.phase = "confirmed";
+        state.confirmed = confirmed;
+        state.draft = null;
+        save();
+        return state;
+      },
+      reset: function () {
+        state = initialState();
+        storage.removeItem(STORAGE_KEY);
+        return state;
+      },
+    };
+  }
+
+  function editValue(current, raw) {
+    if (typeof current === "number") {
+      var number = Number(raw);
+      return Number.isFinite(number) ? number : raw;
+    }
+    if (typeof current === "boolean") return raw === true || raw === "true";
+    return raw;
+  }
+
+  function createCorrections(draft, edits) {
+    var corrections = [];
+    var features = (draft && draft.reported_features) || {};
+    Object.keys(edits).forEach(function (field) {
+      var feature = features[field];
+      if (!feature) return;
+      var value = editValue(feature.normalized_value, edits[field]);
+      if (
+        value === feature.normalized_value &&
+        !["ambiguous", "out_of_range", "conflicting"].includes(feature.status)
+      ) return;
+      corrections.push({
+        field: field,
+        raw_value: value,
+        raw_unit: null,
+        source_text: "Edited in review: " + feature.label,
+        operation: "correct",
+      });
+    });
+    return corrections;
+  }
+
+  return {
+    STORAGE_KEY: STORAGE_KEY,
+    create: create,
+    createCorrections: createCorrections,
+  };
+});

--- a/chatbot/profile-session.test.cjs
+++ b/chatbot/profile-session.test.cjs
@@ -1,0 +1,147 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const profileSession = require("./profile-session.js");
+
+
+function memoryStorage() {
+  const values = new Map();
+  return {
+    getItem(key) {
+      return values.has(key) ? values.get(key) : null;
+    },
+    setItem(key, value) {
+      values.set(key, String(value));
+    },
+    removeItem(key) {
+      values.delete(key);
+    },
+  };
+}
+
+
+const height = {
+  field: "height",
+  raw_value: 180,
+  raw_unit: "cm",
+  source_text: "height 180 cm",
+  operation: "set",
+};
+
+
+test("single-turn and multi-turn candidates stay in one tab-scoped draft", () => {
+  const storage = memoryStorage();
+  const session = profileSession.create(storage);
+
+  session.start();
+  session.appendCandidates([height]);
+  session.appendCandidates([
+    {
+      field: "weight",
+      raw_value: 81,
+      raw_unit: "kg",
+      source_text: "weight 81 kg",
+      operation: "set",
+    },
+  ]);
+
+  assert.equal(session.getState().phase, "draft");
+  assert.deepEqual(
+    session.getState().candidates.map((candidate) => candidate.field),
+    ["height", "weight"],
+  );
+  assert.deepEqual(
+    profileSession.create(storage).getState().candidates,
+    session.getState().candidates,
+  );
+});
+
+
+test("Draft becomes Confirmed only through the explicit confirm transition", () => {
+  const storage = memoryStorage();
+  const session = profileSession.create(storage);
+  session.start();
+  session.appendCandidates([height]);
+  session.applyDraft({ state: "draft", can_confirm: true, reported_features: {} });
+
+  assert.equal(session.getState().phase, "draft");
+
+  session.confirm({
+    state: "confirmed",
+    matching_started: false,
+    reported_features: {},
+  });
+
+  assert.equal(session.getState().phase, "confirmed");
+  assert.equal(session.getState().confirmed.matching_started, false);
+});
+
+
+test("Start Over clears only profile state and keeps unrelated chatbot state", () => {
+  const storage = memoryStorage();
+  storage.setItem("aligatehr-chatbot-history", "unrelated conversation");
+  const session = profileSession.create(storage);
+  session.start();
+  session.appendCandidates([height]);
+
+  session.reset();
+
+  assert.equal(session.getState().phase, "inactive");
+  assert.deepEqual(session.getState().candidates, []);
+  assert.equal(
+    storage.getItem("aligatehr-chatbot-history"),
+    "unrelated conversation",
+  );
+  assert.equal(storage.getItem(profileSession.STORAGE_KEY), null);
+});
+
+
+test("review edits become explicit correction candidates", () => {
+  const corrections = profileSession.createCorrections(
+    {
+      reported_features: {
+        age: {
+          normalized_value: 55,
+          normalized_unit: "years",
+          label: "Age",
+        },
+        smoking_status: {
+          normalized_value: "former",
+          normalized_unit: null,
+          label: "Smoking status",
+        },
+      },
+    },
+    { age: "57", smoking_status: "former" },
+  );
+
+  assert.deepEqual(corrections, [
+    {
+      field: "age",
+      raw_value: 57,
+      raw_unit: null,
+      source_text: "Edited in review: Age",
+      operation: "correct",
+    },
+  ]);
+});
+
+
+test("review can explicitly resolve a conflict in favor of an existing value", () => {
+  const corrections = profileSession.createCorrections(
+    {
+      reported_features: {
+        age: {
+          normalized_value: 55,
+          normalized_unit: "years",
+          label: "Age",
+          status: "conflicting",
+        },
+      },
+    },
+    { age: "55" },
+  );
+
+  assert.equal(corrections[0].operation, "correct");
+  assert.equal(corrections[0].raw_value, 55);
+});

--- a/docs/demo-profile-input-bounds-validation-2026-07-13.md
+++ b/docs/demo-profile-input-bounds-validation-2026-07-13.md
@@ -1,0 +1,35 @@
+# Demo Profile input-bound validation — 2026-07-13
+
+This note records the evidence for the operational validation bounds introduced
+for issue [#25](https://github.com/PatrickTangwen/report-web/issues/25). It does
+not replace the [accepted design](https://github.com/PatrickTangwen/report-web/blob/79b16b4ebf5add5dd8eeb81edab83cc30dcba136/docs/chatbot-embedding-visualization-design-2026-07-13.md)
+or [ADR 0003](https://github.com/PatrickTangwen/report-web/blob/79b16b4ebf5add5dd8eeb81edab83cc30dcba136/docs/adr/0003-limit-profile-matching-to-demo-data.md).
+
+## Evidence and interpretation
+
+The current fibrotic demo source contains 6,010 reference rows. The validator's
+`REFERENCE_SUPPORT` values are the observed minima and maxima of the ten
+continuous fields in that committed source. A contract test reads the CSV and
+proves that every recorded support interval matches those values exactly and is
+contained by the corresponding operational input bound.
+
+The wider `INPUT_BOUNDS` are conservative entry-error envelopes used only to
+separate an uninterpretable value (`out_of_range`) from a valid value that the
+current demo cohort does not represent (`outside_reference_support`). They are
+not healthy ranges, diagnostic intervals, or matching thresholds. Values inside
+the input envelope are never clamped; values beyond reference support remain
+visible. Unit-conversion tests cover centimetres, metres, feet/inches, pounds,
+kilograms, creatinine units, HbA1c units, and derived BMI.
+
+This validation intentionally supports the current Dataset Release only. Before
+a release changes these fields or their units, maintainers must rerun the CSV
+extrema contract, review the operational envelopes, and update this dated note
+instead of silently retaining stale limits. Scientific Profile Coverage and
+matching-threshold calibration remain outside issue #25.
+
+## Reproduction
+
+```bash
+cd chatbot-backend
+python -m pytest -q test_demo_profile.py
+```


### PR DESCRIPTION
## Summary

Implements #25 as a stacked change on #31.

- adds a strict LLM Feature Candidate extraction contract and stateless profile endpoints
- adds deterministic supported-field validation, unit evidence checks/conversion, reference-support flags, conflicts/corrections, blood-pressure splitting, BMI and waist-to-hip derivation
- adds a tab-scoped Profile Draft / Confirmed Profile state machine with editable review, canonical category choices, explicit confirmation, and isolated Start Over
- replaces the chatbot's legacy personal-risk entry point with an explicit research Demo Profile warning
- keeps Drafts and Confirmed Profiles disconnected from cohort matching and risk endpoints; matching remains #26
- records current input-bound evidence in `docs/demo-profile-input-bounds-validation-2026-07-13.md`

## Context

This PR is intentionally based on `codex/issue-24-preset-walkthrough` while #31 remains open. Retarget to `main` after #31 merges.

Authoritative context:

- [accepted design at 79b16b4](https://github.com/PatrickTangwen/report-web/blob/79b16b4ebf5add5dd8eeb81edab83cc30dcba136/docs/chatbot-embedding-visualization-design-2026-07-13.md)
- [ADR 0003](https://github.com/PatrickTangwen/report-web/blob/79b16b4ebf5add5dd8eeb81edab83cc30dcba136/docs/adr/0003-limit-profile-matching-to-demo-data.md)
- [project terminology](https://github.com/PatrickTangwen/report-web/blob/79b16b4ebf5add5dd8eeb81edab83cc30dcba136/CONTEXT.md)

## Validation

- `cd chatbot-backend && python -m pytest -q` — 98 passed
- `node --test chatbot/embedding-demo.test.cjs chatbot/profile-session.test.cjs` — 10 passed
- `node --experimental-default-type=module --test viz/embedding-scatter.test.mjs` — 6 passed
- `python scripts/check_ojs_assets.py` — passed
- `quarto render` — passed; existing unresolved `viz/dashboard.qmd` warning unchanged
- real local browser smoke — extract → validate → edit → re-derive → confirm → Start Over; no browser console errors and no matching/risk request
- final two-axis review — no P0–P2 Standards or Spec findings
