### PR TITLE
Connect live profile matching to the walkthrough

### DIFF
--- a/chatbot-backend/app.py
+++ b/chatbot-backend/app.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from typing import Literal
 
 from openai import OpenAI, APIError
-from fastapi import FastAPI, HTTPException, Query, Request, Response
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
@@ -21,6 +21,7 @@ from demo_profile import (
     confirm_profile,
     parse_feature_candidates,
 )
+from profile_matching import load_matching_release, match_confirmed_profile
 
 INTENT_SYSTEM_PROMPT = (
     "You are an intent classifier. Given a user message, classify it into exactly one "
@@ -141,6 +142,19 @@ class ProfileConfirmRequest(BaseModel):
     draft: ProfileDraftInput
 
 
+class ProfileMatchRequest(BaseModel):
+    confirmed_profile: ProfileDraftInput
+    target: Literal[
+        "CKD",
+        "Cardiac_Fibrosis",
+        "MASH",
+        "Pulmonary_fibrosis",
+        "SSc_Connective_Tissue",
+        "Crohns_Disease",
+        "Fibrosis_of_Skin",
+    ]
+
+
 class FormFieldsResponse(BaseModel):
     disease: str
     disease_label: str
@@ -175,6 +189,16 @@ class AssessResponse(BaseModel):
 
 client: OpenAI | None = None
 profile_rate_limiter = ProfileRateLimiter()
+
+
+def get_profile_matching_release():
+    try:
+        return load_matching_release()
+    except (FileNotFoundError, RuntimeError, ValueError) as error:
+        raise HTTPException(
+            status_code=503,
+            detail=f"Profile matching release unavailable: {error}",
+        )
 
 
 def enforce_profile_rate_limit(request):
@@ -290,6 +314,28 @@ async def profile_confirm(req: ProfileConfirmRequest, request: Request):
         return confirm_profile(req.draft.model_dump())
     except ValueError as error:
         raise HTTPException(status_code=409, detail=str(error))
+
+
+@app.post("/profile/match")
+async def profile_match(
+    req: ProfileMatchRequest,
+    request: Request,
+    release=Depends(get_profile_matching_release),
+):
+    enforce_profile_rate_limit(request)
+    if req.confirmed_profile.state != "confirmed":
+        raise HTTPException(status_code=409, detail="Profile must be explicitly confirmed")
+    try:
+        confirmed = confirm_profile(req.confirmed_profile.model_dump())
+    except ValueError as error:
+        raise HTTPException(status_code=409, detail=str(error))
+    return match_confirmed_profile(
+        confirmed,
+        req.target,
+        release["rows"],
+        release["calibration"],
+        release["dataset_version"],
+    )
 
 
 @app.get("/form-fields", response_model=FormFieldsResponse)

--- a/chatbot-backend/build_fibrotic_release.py
+++ b/chatbot-backend/build_fibrotic_release.py
@@ -74,6 +74,7 @@ def build_release(source, public_dir, private_output, release_date):
     _write_csv(private_output, MATCH_FIELDS, private_rows)
 
     display_digest = hashlib.sha256(display_path.read_bytes()).hexdigest()
+    private_digest = hashlib.sha256(private_output.read_bytes()).hexdigest()
     dataset_version = f"fibrotic-{release_date}-{display_digest[:12]}"
     manifest = {
         "dataset_version": dataset_version,
@@ -82,6 +83,8 @@ def build_release(source, public_dir, private_output, release_date):
         "disease_counts": dict(sorted(disease_counts.items())),
         "public_schema": PUBLIC_FIELDS,
         "display_sha256": display_digest,
+        "private_schema": MATCH_FIELDS,
+        "private_sha256": private_digest,
     }
     (public_dir / "fibrotic_manifest.json").write_text(
         json.dumps(manifest, indent=2) + "\n"

--- a/chatbot-backend/calibrate_profile_matching.py
+++ b/chatbot-backend/calibrate_profile_matching.py
@@ -1,0 +1,160 @@
+"""Generate evidence-driven matching coverage and threshold parameters."""
+
+import argparse
+import csv
+import itertools
+import json
+import warnings
+from pathlib import Path
+
+import numpy as np
+
+from profile_matching import CONTINUOUS_RANGES, DOMAIN_FEATURES, _row_value
+
+
+METHODOLOGY = {
+    "reference_neighbor_count": 5,
+    "minimum_group_size": 5,
+    "maximum_references": 20,
+    "aggregate_cell_suppression_minimum": 5,
+    "stability_median_overlap_minimum": 0.6,
+    "stability_p10_overlap_minimum": 0.2,
+    "distance_threshold_quantile": 0.95,
+}
+
+
+def _feature_matrix(rows, profile_field, row_field, kind):
+    values = [_row_value(row, row_field) for row in rows]
+    if kind == "continuous":
+        array = np.array(
+            [float(value) if value is not None else np.nan for value in values],
+            dtype=float,
+        )
+        low, high = CONTINUOUS_RANGES[profile_field]
+        return np.abs(array[:, None] - array[None, :]) / (high - low)
+    array = np.array(values, dtype=object)
+    available = np.array([value is not None for value in values])
+    differences = (array[:, None] != array[None, :]).astype(float)
+    differences[~(available[:, None] & available[None, :])] = np.nan
+    return differences
+
+
+def _domain_matrices(rows):
+    matrices = {}
+    for domain, features in DOMAIN_FEATURES.items():
+        feature_matrices = [
+            _feature_matrix(rows, profile_field, row_field, kind)
+            for profile_field, row_field, kind in features
+        ]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            matrices[domain] = np.nanmean(feature_matrices, axis=0)
+    return matrices
+
+
+def _combined_distance(matrices, domains):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        distance = np.nanmean([matrices[domain] for domain in domains], axis=0)
+    np.fill_diagonal(distance, np.inf)
+    return distance
+
+
+def _neighbor_indices(distance, count):
+    return np.argpartition(distance, count - 1, axis=1)[:, :count]
+
+
+def _pattern_evidence(distance, full_neighbors, neighbor_count):
+    neighbors = _neighbor_indices(distance, neighbor_count)
+    overlaps = np.array(
+        [
+            len(set(masked) & set(full)) / neighbor_count
+            for masked, full in zip(neighbors, full_neighbors)
+        ]
+    )
+    fifth_distances = np.partition(distance, neighbor_count - 1, axis=1)[
+        :, neighbor_count - 1
+    ]
+    finite = fifth_distances[np.isfinite(fifth_distances)]
+    if not len(finite):
+        return None
+    return {
+        "median_top5_overlap": round(float(np.median(overlaps)), 4),
+        "p10_top5_overlap": round(float(np.quantile(overlaps, 0.1)), 4),
+        "distance_threshold": round(
+            float(
+                np.quantile(
+                    finite,
+                    METHODOLOGY["distance_threshold_quantile"],
+                )
+            ),
+            6,
+        ),
+    }
+
+
+def calibrate_matching(rows, dataset_version):
+    targets = {}
+    neighbor_count = METHODOLOGY["reference_neighbor_count"]
+    for target in sorted({row["disease"] for row in rows}):
+        target_rows = [row for row in rows if row["disease"] == target]
+        if len(target_rows) <= neighbor_count:
+            raise ValueError(
+                f"{target} needs more than {neighbor_count} rows for calibration"
+            )
+        matrices = _domain_matrices(target_rows)
+        domains = list(DOMAIN_FEATURES)
+        full_distance = _combined_distance(matrices, domains)
+        full_neighbors = _neighbor_indices(full_distance, neighbor_count)
+        experiments = {}
+        eligible = {}
+        for count in range(1, len(domains) + 1):
+            for combination in itertools.combinations(domains, count):
+                pattern = "|".join(sorted(combination))
+                distance = _combined_distance(matrices, combination)
+                evidence = _pattern_evidence(
+                    distance,
+                    full_neighbors,
+                    neighbor_count,
+                )
+                if evidence is None:
+                    continue
+                experiments[pattern] = evidence
+                if (
+                    evidence["median_top5_overlap"]
+                    >= METHODOLOGY["stability_median_overlap_minimum"]
+                    and evidence["p10_top5_overlap"]
+                    >= METHODOLOGY["stability_p10_overlap_minimum"]
+                ):
+                    eligible[pattern] = evidence
+        targets[target] = {
+            "reference_count": len(target_rows),
+            "eligible_patterns": eligible,
+            "masking_experiments": experiments,
+        }
+    return {
+        "dataset_version": dataset_version,
+        "methodology": METHODOLOGY,
+        "continuous_ranges": {
+            field: list(bounds) for field, bounds in CONTINUOUS_RANGES.items()
+        },
+        "targets": targets,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--private-artifact", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    with args.private_artifact.open(newline="") as file:
+        rows = list(csv.DictReader(file))
+    manifest = json.loads(args.manifest.read_text())
+    calibration = calibrate_matching(rows, manifest["dataset_version"])
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(calibration, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/chatbot-backend/data/fibrotic_matching_calibration.json
+++ b/chatbot-backend/data/fibrotic_matching_calibration.json
@@ -1,0 +1,2803 @@
+{
+  "dataset_version": "fibrotic-2026-07-13-9d04ee36876b",
+  "methodology": {
+    "reference_neighbor_count": 5,
+    "minimum_group_size": 5,
+    "maximum_references": 20,
+    "aggregate_cell_suppression_minimum": 5,
+    "stability_median_overlap_minimum": 0.6,
+    "stability_p10_overlap_minimum": 0.2,
+    "distance_threshold_quantile": 0.95
+  },
+  "continuous_ranges": {
+    "age": [
+      33.0,
+      90.0
+    ],
+    "bmi": [
+      15.0,
+      60.0
+    ],
+    "waist_to_hip_ratio": [
+      0.6218487394957983,
+      1.3058823529411765
+    ],
+    "sbp": [
+      80.0,
+      220.0
+    ],
+    "dbp": [
+      46.0,
+      120.0
+    ],
+    "creatinine": [
+      20.4,
+      500.0
+    ],
+    "hba1c": [
+      20.0,
+      113.0
+    ]
+  },
+  "targets": {
+    "CKD": {
+      "reference_count": 1500,
+      "eligible_patterns": {
+        "blood_pressure|body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.080907
+        },
+        "blood_pressure|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.083847
+        },
+        "blood_pressure|body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.06755
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.093299
+        },
+        "blood_pressure|body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.080322
+        },
+        "body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.075791
+        },
+        "blood_pressure|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.090759
+        },
+        "blood_pressure|body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.074742
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 1.0,
+          "distance_threshold": 0.097001
+        }
+      },
+      "masking_experiments": {
+        "demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "body_composition": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.027908
+        },
+        "blood_pressure": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.028185
+        },
+        "lifestyle": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.006452
+        },
+        "body_composition|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.038808
+        },
+        "blood_pressure|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.026316
+        },
+        "demographics|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.026316
+        },
+        "demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.004386
+        },
+        "demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.020658
+        },
+        "blood_pressure|body_composition": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.052648
+        },
+        "body_composition|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.045813
+        },
+        "body_composition|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.018613
+        },
+        "body_composition|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.041126
+        },
+        "blood_pressure|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.031187
+        },
+        "blood_pressure|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "blood_pressure|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.030663
+        },
+        "family_history|lifestyle": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.024204
+        },
+        "family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.003446
+        },
+        "blood_pressure|body_composition|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.052574
+        },
+        "body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.061951
+        },
+        "body_composition|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.030597
+        },
+        "body_composition|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.045403
+        },
+        "blood_pressure|demographics|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.061404
+        },
+        "blood_pressure|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.018686
+        },
+        "blood_pressure|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.039885
+        },
+        "demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.035234
+        },
+        "demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.047953
+        },
+        "demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.018138
+        },
+        "blood_pressure|body_composition|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.071689
+        },
+        "blood_pressure|body_composition|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.038396
+        },
+        "blood_pressure|body_composition|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.057328
+        },
+        "body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.046768
+        },
+        "body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.058876
+        },
+        "body_composition|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.032464
+        },
+        "blood_pressure|family_history|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.039741
+        },
+        "blood_pressure|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.052324
+        },
+        "blood_pressure|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.022176
+        },
+        "family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.024502
+        },
+        "blood_pressure|body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.080907
+        },
+        "blood_pressure|body_composition|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.045873
+        },
+        "blood_pressure|body_composition|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.056592
+        },
+        "body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.065916
+        },
+        "body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.06597
+        },
+        "body_composition|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.037646
+        },
+        "blood_pressure|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.083847
+        },
+        "blood_pressure|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.068617
+        },
+        "blood_pressure|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.034331
+        },
+        "demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.061951
+        },
+        "blood_pressure|body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.06755
+        },
+        "blood_pressure|body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.074219
+        },
+        "blood_pressure|body_composition|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.047263
+        },
+        "body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.057973
+        },
+        "blood_pressure|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.052713
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.093299
+        },
+        "blood_pressure|body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.080322
+        },
+        "blood_pressure|body_composition|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.049152
+        },
+        "body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.075791
+        },
+        "blood_pressure|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.090759
+        },
+        "blood_pressure|body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.074742
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 1.0,
+          "distance_threshold": 0.097001
+        }
+      }
+    },
+    "Cardiac_Fibrosis": {
+      "reference_count": 379,
+      "eligible_patterns": {
+        "body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.183021
+        },
+        "blood_pressure|demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.188711
+        },
+        "demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.175439
+        },
+        "blood_pressure|body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.159415
+        },
+        "body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.156207
+        },
+        "body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.144772
+        },
+        "blood_pressure|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.166031
+        },
+        "blood_pressure|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.148934
+        },
+        "demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.144199
+        },
+        "blood_pressure|body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.163728
+        },
+        "body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.141997
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 0.8,
+          "distance_threshold": 0.150259
+        },
+        "blood_pressure|body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.137485
+        },
+        "body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.13374
+        },
+        "blood_pressure|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.140809
+        },
+        "blood_pressure|body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.14098
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 1.0,
+          "distance_threshold": 0.134808
+        }
+      },
+      "masking_experiments": {
+        "demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.008772
+        },
+        "body_composition": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.051233
+        },
+        "blood_pressure": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.050188
+        },
+        "lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.016405
+        },
+        "body_composition|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.058976
+        },
+        "blood_pressure|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.046976
+        },
+        "demographics|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.25
+        },
+        "demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.013158
+        },
+        "demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.029979
+        },
+        "blood_pressure|body_composition": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.070668
+        },
+        "body_composition|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.107046
+        },
+        "body_composition|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.031428
+        },
+        "body_composition|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.052676
+        },
+        "blood_pressure|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.093094
+        },
+        "blood_pressure|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "blood_pressure|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.044559
+        },
+        "family_history|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.25
+        },
+        "lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.054964
+        },
+        "family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.01172
+        },
+        "blood_pressure|body_composition|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.069372
+        },
+        "body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.183021
+        },
+        "body_composition|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.043417
+        },
+        "body_composition|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.057699
+        },
+        "blood_pressure|demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.188711
+        },
+        "blood_pressure|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.043306
+        },
+        "blood_pressure|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.05077
+        },
+        "demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.175439
+        },
+        "demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.175814
+        },
+        "demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.026385
+        },
+        "blood_pressure|body_composition|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.12943
+        },
+        "blood_pressure|body_composition|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.055492
+        },
+        "blood_pressure|body_composition|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.066879
+        },
+        "body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.177322
+        },
+        "body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.1002
+        },
+        "body_composition|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.042272
+        },
+        "blood_pressure|family_history|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.179701
+        },
+        "blood_pressure|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.091121
+        },
+        "blood_pressure|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.032969
+        },
+        "family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.169536
+        },
+        "blood_pressure|body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.159415
+        },
+        "blood_pressure|body_composition|demographics|family_history": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.061546
+        },
+        "blood_pressure|body_composition|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.066404
+        },
+        "body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.156207
+        },
+        "body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.144772
+        },
+        "body_composition|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.048092
+        },
+        "blood_pressure|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.166031
+        },
+        "blood_pressure|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.148934
+        },
+        "blood_pressure|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.045223
+        },
+        "demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.144199
+        },
+        "blood_pressure|body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.163728
+        },
+        "blood_pressure|body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.115712
+        },
+        "blood_pressure|body_composition|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.055604
+        },
+        "body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.141997
+        },
+        "blood_pressure|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.148131
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 0.8,
+          "distance_threshold": 0.150259
+        },
+        "blood_pressure|body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.137485
+        },
+        "blood_pressure|body_composition|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.063113
+        },
+        "body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.13374
+        },
+        "blood_pressure|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.140809
+        },
+        "blood_pressure|body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.14098
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 1.0,
+          "distance_threshold": 0.134808
+        }
+      }
+    },
+    "Crohns_Disease": {
+      "reference_count": 826,
+      "eligible_patterns": {
+        "blood_pressure|demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.084781
+        },
+        "blood_pressure|body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.098952
+        },
+        "body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.138237
+        },
+        "blood_pressure|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.139711
+        },
+        "blood_pressure|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.08292
+        },
+        "demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.133282
+        },
+        "blood_pressure|body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.086949
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.8,
+          "distance_threshold": 0.130627
+        },
+        "blood_pressure|body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.096257
+        },
+        "body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.119016
+        },
+        "blood_pressure|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.120891
+        },
+        "blood_pressure|body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.087687
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 1.0,
+          "distance_threshold": 0.118355
+        }
+      },
+      "masking_experiments": {
+        "demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "body_composition": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.035806
+        },
+        "blood_pressure": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.034266
+        },
+        "lifestyle": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.008593
+        },
+        "body_composition|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.043743
+        },
+        "blood_pressure|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.028834
+        },
+        "demographics|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.04386
+        },
+        "demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.004386
+        },
+        "demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.020833
+        },
+        "blood_pressure|body_composition": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.060725
+        },
+        "body_composition|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.056984
+        },
+        "body_composition|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.020406
+        },
+        "body_composition|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.042988
+        },
+        "blood_pressure|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.052063
+        },
+        "blood_pressure|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "blood_pressure|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.033347
+        },
+        "family_history|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.024891
+        },
+        "family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.005336
+        },
+        "blood_pressure|body_composition|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.061056
+        },
+        "body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.082013
+        },
+        "body_composition|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.035463
+        },
+        "body_composition|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.049223
+        },
+        "blood_pressure|demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.084781
+        },
+        "blood_pressure|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.03127
+        },
+        "blood_pressure|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.040749
+        },
+        "demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.166667
+        },
+        "demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.054374
+        },
+        "demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.019444
+        },
+        "blood_pressure|body_composition|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.083783
+        },
+        "blood_pressure|body_composition|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.043597
+        },
+        "blood_pressure|body_composition|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.05897
+        },
+        "body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.059666
+        },
+        "body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.062946
+        },
+        "body_composition|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.033489
+        },
+        "blood_pressure|family_history|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.067125
+        },
+        "blood_pressure|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.064107
+        },
+        "blood_pressure|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.026892
+        },
+        "family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.039366
+        },
+        "blood_pressure|body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.098952
+        },
+        "blood_pressure|body_composition|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.052659
+        },
+        "blood_pressure|body_composition|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.05921
+        },
+        "body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.138237
+        },
+        "body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.078993
+        },
+        "body_composition|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.041172
+        },
+        "blood_pressure|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.139711
+        },
+        "blood_pressure|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.08292
+        },
+        "blood_pressure|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.03808
+        },
+        "demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.133282
+        },
+        "blood_pressure|body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.086949
+        },
+        "blood_pressure|body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.083104
+        },
+        "blood_pressure|body_composition|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.049541
+        },
+        "body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.067462
+        },
+        "blood_pressure|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.071117
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.8,
+          "distance_threshold": 0.130627
+        },
+        "blood_pressure|body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.096257
+        },
+        "blood_pressure|body_composition|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.053547
+        },
+        "body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.119016
+        },
+        "blood_pressure|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.120891
+        },
+        "blood_pressure|body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.087687
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 1.0,
+          "distance_threshold": 0.118355
+        }
+      }
+    },
+    "Fibrosis_of_Skin": {
+      "reference_count": 1500,
+      "eligible_patterns": {
+        "blood_pressure|body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.081534
+        },
+        "body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.072044
+        },
+        "blood_pressure|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.084145
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.093674
+        },
+        "blood_pressure|body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.07742
+        },
+        "body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.073085
+        },
+        "blood_pressure|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.084162
+        },
+        "blood_pressure|body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.067358
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 1.0,
+          "distance_threshold": 0.092023
+        }
+      },
+      "masking_experiments": {
+        "demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "body_composition": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.024875
+        },
+        "blood_pressure": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.028378
+        },
+        "lifestyle": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.004735
+        },
+        "body_composition|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.034064
+        },
+        "blood_pressure|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.022455
+        },
+        "demographics|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.026316
+        },
+        "demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.004386
+        },
+        "demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.016797
+        },
+        "blood_pressure|body_composition": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.048318
+        },
+        "body_composition|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.040939
+        },
+        "body_composition|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.013785
+        },
+        "body_composition|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.032488
+        },
+        "blood_pressure|lifestyle": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.035569
+        },
+        "blood_pressure|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "blood_pressure|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.024469
+        },
+        "family_history|lifestyle": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.015257
+        },
+        "family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.003097
+        },
+        "blood_pressure|body_composition|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.050997
+        },
+        "body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.062209
+        },
+        "body_composition|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.028878
+        },
+        "body_composition|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.038303
+        },
+        "blood_pressure|demographics|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.072351
+        },
+        "blood_pressure|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.025315
+        },
+        "blood_pressure|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.033311
+        },
+        "demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.046784
+        },
+        "demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.042655
+        },
+        "demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.015134
+        },
+        "blood_pressure|body_composition|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.067948
+        },
+        "blood_pressure|body_composition|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.037563
+        },
+        "blood_pressure|body_composition|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.048654
+        },
+        "body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.043305
+        },
+        "body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.048416
+        },
+        "body_composition|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.025544
+        },
+        "blood_pressure|family_history|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.04302
+        },
+        "blood_pressure|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.043571
+        },
+        "blood_pressure|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.019274
+        },
+        "family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.018629
+        },
+        "blood_pressure|body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.081534
+        },
+        "blood_pressure|body_composition|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.045509
+        },
+        "blood_pressure|body_composition|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.050276
+        },
+        "body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.072044
+        },
+        "body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.061335
+        },
+        "body_composition|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.034429
+        },
+        "blood_pressure|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.084145
+        },
+        "blood_pressure|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.068767
+        },
+        "blood_pressure|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.031452
+        },
+        "demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.057246
+        },
+        "blood_pressure|body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.06744
+        },
+        "blood_pressure|body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.066918
+        },
+        "blood_pressure|body_composition|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.042014
+        },
+        "body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.047385
+        },
+        "blood_pressure|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.049399
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.093674
+        },
+        "blood_pressure|body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.07742
+        },
+        "blood_pressure|body_composition|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.048092
+        },
+        "body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.073085
+        },
+        "blood_pressure|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.084162
+        },
+        "blood_pressure|body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.067358
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 1.0,
+          "distance_threshold": 0.092023
+        }
+      }
+    },
+    "MASH": {
+      "reference_count": 849,
+      "eligible_patterns": {
+        "blood_pressure|body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.09464
+        },
+        "body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.141042
+        },
+        "body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.077979
+        },
+        "blood_pressure|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.142641
+        },
+        "blood_pressure|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.07961
+        },
+        "demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.133938
+        },
+        "blood_pressure|body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.089093
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.132452
+        },
+        "blood_pressure|body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.091309
+        },
+        "body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.122743
+        },
+        "blood_pressure|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.123989
+        },
+        "blood_pressure|body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.089784
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 1.0,
+          "distance_threshold": 0.119835
+        }
+      },
+      "masking_experiments": {
+        "demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.008772
+        },
+        "body_composition": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.032777
+        },
+        "blood_pressure": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.044421
+        },
+        "lifestyle": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.010425
+        },
+        "body_composition|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.044729
+        },
+        "blood_pressure|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.026316
+        },
+        "demographics|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.039474
+        },
+        "demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.004386
+        },
+        "demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.023845
+        },
+        "blood_pressure|body_composition": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.060349
+        },
+        "body_composition|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.055858
+        },
+        "body_composition|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.023207
+        },
+        "body_composition|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.042308
+        },
+        "blood_pressure|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.046573
+        },
+        "blood_pressure|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "blood_pressure|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.031401
+        },
+        "family_history|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.029691
+        },
+        "family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.007778
+        },
+        "blood_pressure|body_composition|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.060618
+        },
+        "body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.072582
+        },
+        "body_composition|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.038854
+        },
+        "body_composition|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.051253
+        },
+        "blood_pressure|demographics|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.077888
+        },
+        "blood_pressure|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.030233
+        },
+        "blood_pressure|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.041612
+        },
+        "demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.166667
+        },
+        "demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.053657
+        },
+        "demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.022064
+        },
+        "blood_pressure|body_composition|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.083661
+        },
+        "blood_pressure|body_composition|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.043703
+        },
+        "blood_pressure|body_composition|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.05914
+        },
+        "body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.066257
+        },
+        "body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.067922
+        },
+        "body_composition|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.034759
+        },
+        "blood_pressure|family_history|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.065122
+        },
+        "blood_pressure|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.060458
+        },
+        "blood_pressure|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.023283
+        },
+        "family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.040651
+        },
+        "blood_pressure|body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.09464
+        },
+        "blood_pressure|body_composition|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.054583
+        },
+        "blood_pressure|body_composition|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.063774
+        },
+        "body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.141042
+        },
+        "body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.077979
+        },
+        "body_composition|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.045077
+        },
+        "blood_pressure|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.142641
+        },
+        "blood_pressure|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.07961
+        },
+        "blood_pressure|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.039202
+        },
+        "demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.133938
+        },
+        "blood_pressure|body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.089093
+        },
+        "blood_pressure|body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.08596
+        },
+        "blood_pressure|body_composition|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.048859
+        },
+        "body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.077043
+        },
+        "blood_pressure|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.074044
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.132452
+        },
+        "blood_pressure|body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.091309
+        },
+        "blood_pressure|body_composition|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.057134
+        },
+        "body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.122743
+        },
+        "blood_pressure|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.123989
+        },
+        "blood_pressure|body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.089784
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 1.0,
+          "distance_threshold": 0.119835
+        }
+      }
+    },
+    "Pulmonary_fibrosis": {
+      "reference_count": 869,
+      "eligible_patterns": {
+        "blood_pressure|body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.092761
+        },
+        "body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.140513
+        },
+        "blood_pressure|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.145295
+        },
+        "blood_pressure|body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.095827
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.130707
+        },
+        "blood_pressure|body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.084735
+        },
+        "body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.119361
+        },
+        "blood_pressure|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.127243
+        },
+        "blood_pressure|body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.088366
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 1.0,
+          "distance_threshold": 0.116588
+        }
+      },
+      "masking_experiments": {
+        "demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.008772
+        },
+        "body_composition": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.031737
+        },
+        "blood_pressure": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.044537
+        },
+        "lifestyle": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.009362
+        },
+        "body_composition|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.040024
+        },
+        "blood_pressure|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.03046
+        },
+        "demographics|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.046491
+        },
+        "demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.004386
+        },
+        "demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.020053
+        },
+        "blood_pressure|body_composition": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.051507
+        },
+        "body_composition|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.054306
+        },
+        "body_composition|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0184
+        },
+        "body_composition|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.037456
+        },
+        "blood_pressure|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.046091
+        },
+        "blood_pressure|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "blood_pressure|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.031297
+        },
+        "family_history|lifestyle": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.022416
+        },
+        "family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.005335
+        },
+        "blood_pressure|body_composition|demographics": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.055995
+        },
+        "body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.072153
+        },
+        "body_composition|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.031441
+        },
+        "body_composition|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.042911
+        },
+        "blood_pressure|demographics|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.076861
+        },
+        "blood_pressure|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.029331
+        },
+        "blood_pressure|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.03807
+        },
+        "demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.166667
+        },
+        "demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.047356
+        },
+        "demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.016677
+        },
+        "blood_pressure|body_composition|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.079589
+        },
+        "blood_pressure|body_composition|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.04122
+        },
+        "blood_pressure|body_composition|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.052911
+        },
+        "body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.062236
+        },
+        "body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.056804
+        },
+        "body_composition|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.030032
+        },
+        "blood_pressure|family_history|lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.07684
+        },
+        "blood_pressure|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.055309
+        },
+        "blood_pressure|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.024223
+        },
+        "family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.032797
+        },
+        "blood_pressure|body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.092761
+        },
+        "blood_pressure|body_composition|demographics|family_history": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.047906
+        },
+        "blood_pressure|body_composition|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.055098
+        },
+        "body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.140513
+        },
+        "body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.16,
+          "distance_threshold": 0.069273
+        },
+        "body_composition|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.03754
+        },
+        "blood_pressure|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.145295
+        },
+        "blood_pressure|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.071419
+        },
+        "blood_pressure|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.035484
+        },
+        "demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.134155
+        },
+        "blood_pressure|body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.095827
+        },
+        "blood_pressure|body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.076276
+        },
+        "blood_pressure|body_composition|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.045832
+        },
+        "body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.065493
+        },
+        "blood_pressure|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.075907
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.130707
+        },
+        "blood_pressure|body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.084735
+        },
+        "blood_pressure|body_composition|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.050527
+        },
+        "body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.119361
+        },
+        "blood_pressure|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.127243
+        },
+        "blood_pressure|body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.088366
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 1.0,
+          "distance_threshold": 0.116588
+        }
+      }
+    },
+    "SSc_Connective_Tissue": {
+      "reference_count": 87,
+      "eligible_patterns": {
+        "demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.279386
+        },
+        "body_composition|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.276971
+        },
+        "blood_pressure|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.305319
+        },
+        "family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.25
+        },
+        "body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.24033
+        },
+        "blood_pressure|demographics|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.245125
+        },
+        "demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.33538
+        },
+        "demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.204048
+        },
+        "blood_pressure|body_composition|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.264232
+        },
+        "body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.235041
+        },
+        "body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.20699
+        },
+        "blood_pressure|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.25
+        },
+        "blood_pressure|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.222012
+        },
+        "family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.22882
+        },
+        "blood_pressure|body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.32,
+          "distance_threshold": 0.216181
+        },
+        "body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.26707
+        },
+        "body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.186946
+        },
+        "blood_pressure|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.26867
+        },
+        "blood_pressure|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.184895
+        },
+        "demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.260637
+        },
+        "blood_pressure|body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.233536
+        },
+        "blood_pressure|body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.188399
+        },
+        "body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.198588
+        },
+        "blood_pressure|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.22226
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 0.8,
+          "distance_threshold": 0.238832
+        },
+        "blood_pressure|body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.32,
+          "distance_threshold": 0.181309
+        },
+        "body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.224963
+        },
+        "blood_pressure|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.8,
+          "distance_threshold": 0.236739
+        },
+        "blood_pressure|body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.199244
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 1.0,
+          "distance_threshold": 0.213005
+        }
+      },
+      "masking_experiments": {
+        "demographics": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.041228
+        },
+        "body_composition": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.094096
+        },
+        "blood_pressure": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.088847
+        },
+        "lifestyle": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.5
+        },
+        "family_history": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.0
+        },
+        "optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.034832
+        },
+        "body_composition|demographics": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.092262
+        },
+        "blood_pressure|demographics": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.085493
+        },
+        "demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.279386
+        },
+        "demographics|family_history": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.04693
+        },
+        "demographics|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.061537
+        },
+        "blood_pressure|body_composition": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.101039
+        },
+        "body_composition|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.276971
+        },
+        "body_composition|family_history": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.059935
+        },
+        "body_composition|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.067087
+        },
+        "blood_pressure|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.305319
+        },
+        "blood_pressure|family_history": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.068649
+        },
+        "blood_pressure|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.055913
+        },
+        "family_history|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.25
+        },
+        "lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.4,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.262046
+        },
+        "family_history|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.019261
+        },
+        "blood_pressure|body_composition|demographics": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.112684
+        },
+        "body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.24033
+        },
+        "body_composition|demographics|family_history": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.087973
+        },
+        "body_composition|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.07701
+        },
+        "blood_pressure|demographics|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.245125
+        },
+        "blood_pressure|demographics|family_history": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.090242
+        },
+        "blood_pressure|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.075629
+        },
+        "demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.33538
+        },
+        "demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.204048
+        },
+        "demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.062149
+        },
+        "blood_pressure|body_composition|lifestyle": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.264232
+        },
+        "blood_pressure|body_composition|family_history": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.097166
+        },
+        "blood_pressure|body_composition|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.087106
+        },
+        "body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.235041
+        },
+        "body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.20699
+        },
+        "body_composition|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.0,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.051535
+        },
+        "blood_pressure|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.25
+        },
+        "blood_pressure|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.222012
+        },
+        "blood_pressure|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.07016
+        },
+        "family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.22882
+        },
+        "blood_pressure|body_composition|demographics|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.32,
+          "distance_threshold": 0.216181
+        },
+        "blood_pressure|body_composition|demographics|family_history": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.121576
+        },
+        "blood_pressure|body_composition|demographics|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.092249
+        },
+        "body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.26707
+        },
+        "body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.186946
+        },
+        "body_composition|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.089464
+        },
+        "blood_pressure|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.26867
+        },
+        "blood_pressure|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.2,
+          "distance_threshold": 0.184895
+        },
+        "blood_pressure|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.092682
+        },
+        "demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.260637
+        },
+        "blood_pressure|body_composition|family_history|lifestyle": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.233536
+        },
+        "blood_pressure|body_composition|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.6,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.188399
+        },
+        "blood_pressure|body_composition|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.083022
+        },
+        "body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.198588
+        },
+        "blood_pressure|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.4,
+          "distance_threshold": 0.22226
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 0.8,
+          "distance_threshold": 0.238832
+        },
+        "blood_pressure|body_composition|demographics|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.32,
+          "distance_threshold": 0.181309
+        },
+        "blood_pressure|body_composition|demographics|family_history|optional_laboratory": {
+          "median_top5_overlap": 0.2,
+          "p10_top5_overlap": 0.0,
+          "distance_threshold": 0.110871
+        },
+        "body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.224963
+        },
+        "blood_pressure|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.8,
+          "distance_threshold": 0.236739
+        },
+        "blood_pressure|body_composition|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 0.8,
+          "p10_top5_overlap": 0.6,
+          "distance_threshold": 0.199244
+        },
+        "blood_pressure|body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+          "median_top5_overlap": 1.0,
+          "p10_top5_overlap": 1.0,
+          "distance_threshold": 0.213005
+        }
+      }
+    }
+  }
+}

--- a/chatbot-backend/data/fibrotic_release/fibrotic_manifest.json
+++ b/chatbot-backend/data/fibrotic_release/fibrotic_manifest.json
@@ -18,5 +18,24 @@
     "tsne_x",
     "tsne_y"
   ],
-  "display_sha256": "9d04ee36876bdec4c1c0ecf3618beb67876cef8217fd80f95defdd2f6ea94c60"
+  "display_sha256": "9d04ee36876bdec4c1c0ecf3618beb67876cef8217fd80f95defdd2f6ea94c60",
+  "private_schema": [
+    "visual_reference_id",
+    "disease",
+    "age_recruit",
+    "sex",
+    "BMI",
+    "waist",
+    "hip",
+    "height",
+    "weight",
+    "DBP",
+    "SBP",
+    "creatinine",
+    "HbA1c",
+    "smoking_status",
+    "alcohol_freq",
+    "has_affected_rel"
+  ],
+  "private_sha256": "518b472187ca66d62ae519ecbef796d7f172d3772211d7837de8ddb0b53874fc"
 }

--- a/chatbot-backend/profile_matching.py
+++ b/chatbot-backend/profile_matching.py
@@ -1,0 +1,358 @@
+"""Deterministic profile matching for the fibrotic reference cohort."""
+
+import csv
+import hashlib
+import json
+from collections import Counter
+from functools import lru_cache
+from pathlib import Path
+from statistics import median
+
+from fibrotic_contract import MATCH_FIELDS, PUBLIC_FIELDS, TARGETS
+
+
+CONTINUOUS_RANGES = {
+    "age": (33.0, 90.0),
+    "bmi": (15.0, 60.0),
+    "waist_to_hip_ratio": (0.6218487394957983, 1.3058823529411765),
+    "sbp": (80.0, 220.0),
+    "dbp": (46.0, 120.0),
+    "creatinine": (20.4, 500.0),
+    "hba1c": (20.0, 113.0),
+}
+CATEGORY_VALUES = {
+    "sex": {"female": "0", "male": "1"},
+    "smoking_status": {"never": "0", "former": "1", "current": "2"},
+    "alcohol_frequency": {
+        "daily_or_almost_daily": "1",
+        "three_to_four_per_week": "2",
+        "one_to_two_per_week": "3",
+        "one_to_three_per_month": "4",
+        "special_occasions": "5",
+        "never": "6",
+    },
+    "affected_relative": {False: "0", True: "1"},
+}
+DOMAIN_FEATURES = {
+    "demographics": (
+        ("age", "age_recruit", "continuous"),
+        ("sex", "sex", "categorical"),
+    ),
+    "body_composition": (
+        ("bmi", "BMI", "continuous"),
+        ("waist_to_hip_ratio", "waist_to_hip_ratio", "continuous"),
+    ),
+    "blood_pressure": (
+        ("sbp", "SBP", "continuous"),
+        ("dbp", "DBP", "continuous"),
+    ),
+    "lifestyle": (
+        ("smoking_status", "smoking_status", "categorical"),
+        ("alcohol_frequency", "alcohol_freq", "categorical"),
+    ),
+    "family_history": (
+        ("affected_relative", "has_affected_rel", "categorical"),
+    ),
+    "optional_laboratory": (
+        ("creatinine", "creatinine", "continuous"),
+        ("hba1c", "HbA1c", "continuous"),
+    ),
+}
+FEATURE_PRESENTATION = {
+    "age": ("Age", "years"),
+    "bmi": ("BMI", "kg/m²"),
+    "waist_to_hip_ratio": ("Waist-to-hip ratio", "ratio"),
+    "sbp": ("Systolic blood pressure", "mmHg"),
+    "dbp": ("Diastolic blood pressure", "mmHg"),
+    "creatinine": ("Creatinine", "µmol/L"),
+    "hba1c": ("HbA1c", "mmol/mol"),
+    "sex": ("Sex", None),
+    "smoking_status": ("Smoking status", None),
+    "alcohol_frequency": ("Alcohol frequency", None),
+    "affected_relative": ("Affected relative", None),
+}
+@lru_cache(maxsize=1)
+def load_matching_release():
+    data_dir = Path(__file__).parent / "data"
+    return read_matching_release(
+        data_dir / "private" / "fibrotic_match.csv",
+        data_dir / "fibrotic_release" / "fibrotic_embedding.csv",
+        data_dir / "fibrotic_release" / "fibrotic_manifest.json",
+        data_dir / "fibrotic_matching_calibration.json",
+    )
+
+
+def read_matching_release(private_path, display_path, manifest_path, calibration_path):
+    manifest = json.loads(Path(manifest_path).read_text())
+    calibration = json.loads(Path(calibration_path).read_text())
+    private_path = Path(private_path)
+    with private_path.open(newline="") as file:
+        reader = csv.DictReader(file)
+        rows = list(reader)
+        private_schema = reader.fieldnames
+    with Path(display_path).open(newline="") as file:
+        reader = csv.DictReader(file)
+        display_rows = list(reader)
+        display_schema = reader.fieldnames
+
+    if private_schema != MATCH_FIELDS or manifest.get("private_schema") != MATCH_FIELDS:
+        raise RuntimeError("Fibrotic private matching schema is not approved")
+    if display_schema != PUBLIC_FIELDS:
+        raise RuntimeError("Fibrotic display schema is not approved")
+    private_digest = hashlib.sha256(private_path.read_bytes()).hexdigest()
+    if private_digest != manifest.get("private_sha256"):
+        raise RuntimeError("Fibrotic private artifact does not match its manifest")
+    if calibration["dataset_version"] != manifest["dataset_version"]:
+        raise RuntimeError("Matching calibration belongs to another Dataset Release")
+    private_ids = [row["visual_reference_id"] for row in rows]
+    display_ids = [row["visual_reference_id"] for row in display_rows]
+    if (
+        len(private_ids) != len(set(private_ids))
+        or len(display_ids) != len(set(display_ids))
+        or set(private_ids) != set(display_ids)
+    ):
+        raise RuntimeError(
+            "Private and display Visual Reference IDs must have a one-to-one mapping"
+        )
+    if not {row["disease"] for row in rows} <= TARGETS:
+        raise RuntimeError("Private artifact contains an unsupported comparison target")
+    return {
+        "dataset_version": manifest["dataset_version"],
+        "rows": rows,
+        "calibration": calibration,
+    }
+
+
+def _profile_values(confirmed_profile):
+    values = {}
+    for field, feature in confirmed_profile.get("reported_features", {}).items():
+        if feature.get("status") not in {"valid", "outside_reference_support"}:
+            continue
+        value = feature.get("normalized_value")
+        if field in CATEGORY_VALUES:
+            value = CATEGORY_VALUES[field].get(value)
+        if value is not None:
+            values[field] = value
+    derived = confirmed_profile.get("derived_features", {})
+    for field in ("bmi", "waist_to_hip_ratio"):
+        feature = derived.get(field)
+        if feature and feature.get("status") in {"valid", "outside_reference_support"}:
+            values[field] = feature.get("value")
+    return values
+
+
+def _row_value(row, row_field):
+    if row_field == "waist_to_hip_ratio":
+        if not row.get("waist") or not row.get("hip") or float(row["hip"]) == 0:
+            return None
+        return round(float(row["waist"]) / float(row["hip"]), 2)
+    value = row.get(row_field)
+    if value in {None, "", "-3"}:
+        return None
+    return value
+
+
+def _category_code(value):
+    text = str(value)
+    try:
+        number = float(text)
+    except ValueError:
+        return text
+    return str(int(number)) if number.is_integer() else str(number)
+
+
+def _distance(profile_values, row):
+    domain_distances = []
+    for features in DOMAIN_FEATURES.values():
+        differences = []
+        for profile_field, row_field, kind in features:
+            row_value = _row_value(row, row_field)
+            if profile_field not in profile_values or row_value is None:
+                continue
+            if kind == "continuous":
+                low, high = CONTINUOUS_RANGES[profile_field]
+                difference = abs(float(profile_values[profile_field]) - float(row_value)) / (high - low)
+            else:
+                difference = (
+                    0.0
+                    if _category_code(profile_values[profile_field])
+                    == _category_code(row_value)
+                    else 1.0
+                )
+            differences.append(difference)
+        if differences:
+            domain_distances.append(sum(differences) / len(differences))
+    if not domain_distances:
+        return None
+    return sum(domain_distances) / len(domain_distances)
+
+
+def _aggregate_callout(profile_values, selected_rows, suppression_minimum):
+    domains = []
+    for domain, features in DOMAIN_FEATURES.items():
+        metrics = []
+        for profile_field, row_field, kind in features:
+            if profile_field not in profile_values:
+                continue
+            if kind == "categorical":
+                reverse = {
+                    _category_code(encoded): category
+                    for category, encoded in CATEGORY_VALUES[profile_field].items()
+                }
+                counts = Counter(
+                    reverse.get(_category_code(value), str(value))
+                    for row in selected_rows
+                    if (value := _row_value(row, row_field)) is not None
+                )
+                if counts:
+                    label, _ = FEATURE_PRESENTATION[profile_field]
+                    metric = {"feature": profile_field, "label": label}
+                    missing_count = len(selected_rows) - sum(counts.values())
+                    has_sparse_missing_cell = 0 < missing_count < suppression_minimum
+                    if (
+                        min(counts.values()) < suppression_minimum
+                        or has_sparse_missing_cell
+                    ):
+                        metric["suppressed"] = True
+                    else:
+                        metric["distribution"] = [
+                            {"category": category, "count": count}
+                            for category, count in sorted(
+                                counts.items(), key=lambda item: str(item[0])
+                            )
+                        ]
+                    metrics.append(metric)
+                continue
+            values = [
+                float(value)
+                for row in selected_rows
+                if (value := _row_value(row, row_field)) is not None
+            ]
+            if not values:
+                continue
+            label, unit = FEATURE_PRESENTATION[profile_field]
+            missing_count = len(selected_rows) - len(values)
+            has_sparse_missing_cell = 0 < missing_count < suppression_minimum
+            if len(values) < suppression_minimum or has_sparse_missing_cell:
+                metrics.append(
+                    {
+                        "feature": profile_field,
+                        "label": label,
+                        "suppressed": True,
+                    }
+                )
+                continue
+            metrics.append(
+                {
+                    "feature": profile_field,
+                    "label": label,
+                    "unit": unit,
+                    "median": round(float(median(values)), 2),
+                    "range": [round(min(values), 2), round(max(values), 2)],
+                }
+            )
+        if metrics:
+            domains.append({"domain": domain, "metrics": metrics})
+    return {
+        "reference_count": len(selected_rows),
+        "title": "Matched reference neighborhood",
+        "description": "Release-controlled aggregate context; sparse cells are suppressed.",
+        "domains": domains,
+    }
+
+
+def _recommended_missing_domain(available_domains, eligible_patterns):
+    available = set(available_domains)
+    candidates = []
+    for pattern, evidence in eligible_patterns.items():
+        domains = set(pattern.split("|"))
+        if not available <= domains:
+            continue
+        missing = domains - available
+        if len(missing) != 1:
+            continue
+        candidates.append(
+            (
+                -evidence.get("p10_top5_overlap", 0),
+                -evidence.get("median_top5_overlap", 0),
+                pattern,
+                missing.pop(),
+            )
+        )
+    return min(candidates)[3] if candidates else None
+
+
+def match_confirmed_profile(confirmed_profile, target, rows, calibration, dataset_version):
+    values = _profile_values(confirmed_profile)
+    available_domains = [
+        domain
+        for domain, features in DOMAIN_FEATURES.items()
+        if any(feature[0] in values for feature in features)
+    ]
+    pattern = "|".join(sorted(available_domains))
+    target_calibration = calibration.get("targets", {}).get(target, {})
+    eligible_patterns = target_calibration.get("eligible_patterns", {})
+    pattern_calibration = eligible_patterns.get(pattern)
+    if not pattern_calibration:
+        profile_coverage = {"available_domains": available_domains, "eligible": False}
+        recommended = _recommended_missing_domain(available_domains, eligible_patterns)
+        if recommended:
+            profile_coverage["recommended_missing_domain"] = recommended
+        return {
+            "dataset_version": dataset_version,
+            "cohort_comparison_result": {
+                "status": "insufficient_profile_coverage",
+                "target": target,
+                "profile_coverage": profile_coverage,
+            },
+            "visual_reference_ids": [],
+            "aggregate_callout_data": None,
+        }
+
+    qualified = []
+    threshold = pattern_calibration["distance_threshold"]
+    for row in rows:
+        if row.get("disease") != target:
+            continue
+        distance = _distance(values, row)
+        if distance is not None and distance <= threshold:
+            qualified.append((distance, row["visual_reference_id"], row))
+    qualified.sort(key=lambda item: (item[0], item[1]))
+    maximum = calibration["methodology"]["maximum_references"]
+    selected = qualified[:maximum]
+    visual_reference_ids = [reference_id for _, reference_id, _ in selected]
+    minimum = calibration["methodology"]["minimum_group_size"]
+    status = (
+        "matched_reference_neighborhood"
+        if len(visual_reference_ids) >= minimum
+        else "no_stable_neighborhood"
+    )
+    if status == "no_stable_neighborhood":
+        visual_reference_ids = []
+    return {
+        "dataset_version": dataset_version,
+        "cohort_comparison_result": {
+            "status": status,
+            "target": target,
+            "profile_coverage": {
+                "available_domains": available_domains,
+                "eligible": True,
+                "calibration_pattern": pattern,
+            },
+            "matching_domains": available_domains,
+            "neighborhood_size": len(visual_reference_ids),
+            "limitations": [
+                "Research cohort comparison only; the Demo Profile is not embedded and no diagnosis, prognosis, or personal outcome is inferred."
+            ],
+        },
+        "visual_reference_ids": visual_reference_ids,
+        "aggregate_callout_data": (
+            _aggregate_callout(
+                values,
+                [row for _, _, row in selected],
+                calibration["methodology"]["aggregate_cell_suppression_minimum"],
+            )
+            if visual_reference_ids
+            else None
+        ),
+    }

--- a/chatbot-backend/test_fibrotic_release.py
+++ b/chatbot-backend/test_fibrotic_release.py
@@ -1,4 +1,5 @@
 import csv
+import hashlib
 import json
 import subprocess
 import sys
@@ -120,6 +121,9 @@ def test_release_cli_builds_linked_display_and_private_artifacts(tmp_path):
     }
     assert "eid" not in private_rows[0]
     assert "id" not in private_rows[0]
+    assert not {"tsne_x", "tsne_y", "group", "p_true", "p_max", "correct"} & set(
+        private_rows[0]
+    )
 
     display_ids = [row["visual_reference_id"] for row in display_rows]
     private_ids = [row["visual_reference_id"] for row in private_rows]
@@ -131,6 +135,8 @@ def test_release_cli_builds_linked_display_and_private_artifacts(tmp_path):
     assert manifest["dataset_version"].startswith("fibrotic-2026-07-13-")
     assert manifest["point_count"] == 21
     assert manifest["public_schema"] == list(display_rows[0])
+    assert manifest["private_schema"] == list(private_rows[0])
+    assert manifest["private_sha256"] == hashlib.sha256(private_path.read_bytes()).hexdigest()
     assert set(manifest["disease_counts"]) == {disease for disease, _, _ in TARGETS}
 
     assert preset["dataset_version"] == manifest["dataset_version"]

--- a/chatbot-backend/test_profile_matching.py
+++ b/chatbot-backend/test_profile_matching.py
@@ -1,0 +1,578 @@
+from copy import deepcopy
+import csv
+import hashlib
+import json
+
+import pytest_asyncio
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app import app, get_profile_matching_release
+from demo_profile import build_profile_draft, confirm_profile
+from calibrate_profile_matching import calibrate_matching
+from fibrotic_contract import MATCH_FIELDS, PUBLIC_FIELDS
+from profile_matching import match_confirmed_profile, read_matching_release
+
+
+def candidate(field, value, unit=None, source=None):
+    return {
+        "field": field,
+        "raw_value": value,
+        "raw_unit": unit,
+        "source_text": source or f"{field} {value}",
+        "operation": "set",
+    }
+
+
+def confirmed_profile(*candidates):
+    return confirm_profile(build_profile_draft(list(candidates)))
+
+
+@pytest_asyncio.fixture
+async def api_client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+def test_matching_is_target_scoped_and_ignores_visualization_and_outcome_fields():
+    profile = confirmed_profile(
+        candidate("age", 55, source="age 55"),
+        candidate("sex", "female", source="sex female"),
+    )
+    rows = []
+    for index in range(5):
+        rows.append(
+            {
+                "visual_reference_id": f"vr_ckd_{index}",
+                "disease": "CKD",
+                "age_recruit": "55",
+                "sex": "0",
+                "tsne_x": str(index * 1000),
+                "tsne_y": str(index * -1000),
+                "p_true": str(index / 10),
+            }
+        )
+        rows.append(
+            {
+                "visual_reference_id": f"vr_mash_{index}",
+                "disease": "MASH",
+                "age_recruit": "55",
+                "sex": "0",
+                "tsne_x": "0",
+                "tsne_y": "0",
+                "p_true": "1",
+            }
+        )
+    calibration = {
+        "methodology": {
+            "minimum_group_size": 5,
+            "maximum_references": 20,
+            "aggregate_cell_suppression_minimum": 5,
+        },
+        "targets": {
+            "CKD": {
+                "eligible_patterns": {
+                    "demographics": {"distance_threshold": 0.01}
+                }
+            }
+        },
+    }
+
+    first = match_confirmed_profile(
+        profile,
+        "CKD",
+        rows,
+        calibration,
+        "fibrotic-test-release",
+    )
+    changed_prohibited_fields = deepcopy(rows)
+    for row in changed_prohibited_fields:
+        row["tsne_x"] = "999999"
+        row["tsne_y"] = "-999999"
+        row["p_true"] = "0" if row["p_true"] != "0" else "1"
+    second = match_confirmed_profile(
+        profile,
+        "CKD",
+        changed_prohibited_fields,
+        calibration,
+        "fibrotic-test-release",
+    )
+
+    assert first["visual_reference_ids"] == [f"vr_ckd_{index}" for index in range(5)]
+    assert second["visual_reference_ids"] == first["visual_reference_ids"]
+    assert "p_true" not in str(first)
+    assert "tsne" not in str(first).lower()
+
+
+def test_matching_uses_derived_features_and_balances_features_within_domains():
+    profile = confirmed_profile(
+        candidate("age", 55, source="age 55"),
+        candidate("sex", "female", source="sex female"),
+        candidate("height", 180, "cm", "height 180 cm"),
+        candidate("weight", 81, "kg", "weight 81 kg"),
+        candidate("waist", 80, "cm", "waist 80 cm"),
+        candidate("hip", 100, "cm", "hip 100 cm"),
+        candidate("blood_pressure", "120/80", source="blood pressure 120/80"),
+        candidate("smoking_status", "former", source="smoking former"),
+        candidate(
+            "alcohol_frequency",
+            "once or twice a week",
+            source="alcohol once or twice a week",
+        ),
+        candidate("affected_relative", "yes", source="affected relative yes"),
+        candidate("creatinine", 100, "umol/L", "creatinine 100 umol/L"),
+        candidate("hba1c", 42, "mmol/mol", "HbA1c 42 mmol/mol"),
+    )
+    rows = []
+    for index in range(5):
+        rows.append(
+            {
+                "visual_reference_id": f"vr_exact_{index}",
+                "disease": "MASH",
+                "age_recruit": "55",
+                "sex": "0",
+                "BMI": "25",
+                "waist": "80",
+                "hip": "100",
+                # Raw height and weight are intentionally incompatible. They must
+                # not receive extra weight beside the derived BMI match feature.
+                "height": "140",
+                "weight": "165",
+                "DBP": "80",
+                "SBP": "120",
+                "creatinine": "100",
+                "HbA1c": "42",
+                "smoking_status": "1",
+                "alcohol_freq": "3.0",
+                "has_affected_rel": "1",
+            }
+        )
+    calibration = {
+        "methodology": {
+            "minimum_group_size": 5,
+            "maximum_references": 20,
+            "aggregate_cell_suppression_minimum": 5,
+        },
+        "targets": {
+            "MASH": {
+                "eligible_patterns": {
+                    "blood_pressure|body_composition|demographics|family_history|lifestyle|optional_laboratory": {
+                        "distance_threshold": 0.001
+                    }
+                }
+            }
+        },
+    }
+
+    result = match_confirmed_profile(
+        profile,
+        "MASH",
+        rows,
+        calibration,
+        "fibrotic-test-release",
+    )
+
+    assert result["visual_reference_ids"] == [f"vr_exact_{index}" for index in range(5)]
+    assert result["cohort_comparison_result"]["profile_coverage"]["available_domains"] == [
+        "demographics",
+        "body_composition",
+        "blood_pressure",
+        "lifestyle",
+        "family_history",
+        "optional_laboratory",
+    ]
+    lifestyle = next(
+        domain
+        for domain in result["aggregate_callout_data"]["domains"]
+        if domain["domain"] == "lifestyle"
+    )
+    assert lifestyle["metrics"] == [
+        {
+            "feature": "smoking_status",
+            "label": "Smoking status",
+            "distribution": [{"category": "former", "count": 5}],
+        },
+        {
+            "feature": "alcohol_frequency",
+            "label": "Alcohol frequency",
+            "distribution": [{"category": "one_to_two_per_week", "count": 5}],
+        },
+    ]
+
+
+def test_adaptive_neighborhood_caps_at_twenty_and_keeps_callouts_aggregate_only():
+    profile = confirmed_profile(candidate("age", 55, source="age 55"))
+    rows = [
+        {
+            "visual_reference_id": f"vr_{index:02d}",
+            "disease": "CKD",
+            "age_recruit": "55",
+            "sex": "0",
+        }
+        for index in range(25)
+    ]
+    calibration = {
+        "methodology": {
+            "minimum_group_size": 5,
+            "maximum_references": 20,
+            "aggregate_cell_suppression_minimum": 5,
+        },
+        "targets": {
+            "CKD": {
+                "eligible_patterns": {
+                    "demographics": {"distance_threshold": 0.01}
+                }
+            }
+        },
+    }
+
+    result = match_confirmed_profile(
+        profile,
+        "CKD",
+        rows,
+        calibration,
+        "fibrotic-test-release",
+    )
+
+    assert list(result) == [
+        "dataset_version",
+        "cohort_comparison_result",
+        "visual_reference_ids",
+        "aggregate_callout_data",
+    ]
+    assert len(result["visual_reference_ids"]) == 20
+    assert result["cohort_comparison_result"] == {
+        "status": "matched_reference_neighborhood",
+        "target": "CKD",
+        "profile_coverage": {
+            "available_domains": ["demographics"],
+            "eligible": True,
+            "calibration_pattern": "demographics",
+        },
+        "matching_domains": ["demographics"],
+        "neighborhood_size": 20,
+        "limitations": [
+            "Research cohort comparison only; the Demo Profile is not embedded and no diagnosis, prognosis, or personal outcome is inferred."
+        ],
+    }
+    aggregate = result["aggregate_callout_data"]
+    assert aggregate["domains"] == [
+        {
+            "domain": "demographics",
+            "metrics": [
+                {
+                    "feature": "age",
+                    "label": "Age",
+                    "unit": "years",
+                    "median": 55.0,
+                    "range": [55.0, 55.0],
+                }
+            ],
+        }
+    ]
+    assert "visual_reference" not in str(aggregate).lower()
+    assert "risk" not in str(result).lower()
+    assert "similarity" not in str(result).lower()
+
+
+def test_aggregate_callouts_suppress_sparse_categorical_cells():
+    profile = confirmed_profile(
+        candidate("age", 55, source="age 55"),
+        candidate("smoking_status", "former", source="former smoker"),
+        candidate("creatinine", 100, "umol/L", "creatinine 100 umol/L"),
+    )
+    rows = [
+        {
+            "visual_reference_id": f"vr_{index}",
+            "disease": "MASH",
+            "age_recruit": "55",
+            "smoking_status": "1" if index < 5 else "",
+            "creatinine": "100" if index < 5 else "",
+        }
+        for index in range(6)
+    ]
+    calibration = {
+        "methodology": {
+            "minimum_group_size": 5,
+            "maximum_references": 20,
+            "aggregate_cell_suppression_minimum": 5,
+        },
+        "targets": {
+            "MASH": {
+                "eligible_patterns": {
+                    "demographics|lifestyle|optional_laboratory": {
+                        "distance_threshold": 1.0
+                    }
+                }
+            }
+        },
+    }
+
+    result = match_confirmed_profile(
+        profile,
+        "MASH",
+        rows,
+        calibration,
+        "fibrotic-test-release",
+    )
+
+    lifestyle = next(
+        domain
+        for domain in result["aggregate_callout_data"]["domains"]
+        if domain["domain"] == "lifestyle"
+    )
+    assert lifestyle["metrics"] == [
+        {
+            "feature": "smoking_status",
+            "label": "Smoking status",
+            "suppressed": True,
+        }
+    ]
+    optional_laboratory = next(
+        domain
+        for domain in result["aggregate_callout_data"]["domains"]
+        if domain["domain"] == "optional_laboratory"
+    )
+    assert optional_laboratory["metrics"] == [
+        {
+            "feature": "creatinine",
+            "label": "Creatinine",
+            "suppressed": True,
+        }
+    ]
+
+
+def test_insufficient_coverage_requests_the_nearest_calibrated_missing_domain():
+    profile = confirmed_profile(candidate("age", 55, source="age 55"))
+    calibration = {
+        "methodology": {
+            "minimum_group_size": 5,
+            "maximum_references": 20,
+            "aggregate_cell_suppression_minimum": 5,
+        },
+        "targets": {
+            "MASH": {
+                "eligible_patterns": {
+                    "demographics|lifestyle": {"distance_threshold": 0.2},
+                    "body_composition|demographics|lifestyle": {
+                        "distance_threshold": 0.15
+                    },
+                }
+            }
+        },
+    }
+
+    result = match_confirmed_profile(
+        profile,
+        "MASH",
+        [],
+        calibration,
+        "fibrotic-test-release",
+    )
+
+    comparison = result["cohort_comparison_result"]
+    assert comparison["status"] == "insufficient_profile_coverage"
+    assert comparison["profile_coverage"] == {
+        "available_domains": ["demographics"],
+        "eligible": False,
+        "recommended_missing_domain": "lifestyle",
+    }
+    assert result["visual_reference_ids"] == []
+    assert result["aggregate_callout_data"] is None
+
+
+def test_threshold_failure_returns_no_stable_neighborhood_without_forced_neighbors():
+    profile = confirmed_profile(candidate("age", 33, source="age 33"))
+    rows = [
+        {
+            "visual_reference_id": f"vr_far_{index}",
+            "disease": "CKD",
+            "age_recruit": "90",
+            "sex": "0",
+        }
+        for index in range(30)
+    ]
+    calibration = {
+        "methodology": {
+            "minimum_group_size": 5,
+            "maximum_references": 20,
+            "aggregate_cell_suppression_minimum": 5,
+        },
+        "targets": {
+            "CKD": {
+                "eligible_patterns": {
+                    "demographics": {"distance_threshold": 0.05}
+                }
+            }
+        },
+    }
+
+    result = match_confirmed_profile(
+        profile,
+        "CKD",
+        rows,
+        calibration,
+        "fibrotic-test-release",
+    )
+
+    assert result["cohort_comparison_result"]["status"] == "no_stable_neighborhood"
+    assert result["cohort_comparison_result"]["neighborhood_size"] == 0
+    assert result["visual_reference_ids"] == []
+    assert result["aggregate_callout_data"] is None
+
+
+def test_calibration_records_masking_stability_and_fifth_neighbor_thresholds():
+    rows = []
+    for index in range(12):
+        rows.append(
+            {
+                "visual_reference_id": f"vr_{index}",
+                "disease": "CKD",
+                "age_recruit": str(40 + index),
+                "sex": str(index % 2),
+                "BMI": str(20 + index),
+                "waist": str(80 + index),
+                "hip": str(100 + index),
+                "height": str(160 + index),
+                "weight": str(60 + index),
+                "DBP": str(70 + index),
+                "SBP": str(110 + index),
+                "creatinine": str(60 + index),
+                "HbA1c": str(30 + index),
+                "smoking_status": str(index % 3),
+                "alcohol_freq": str((index % 6) + 1),
+                "has_affected_rel": str(index % 2),
+            }
+        )
+
+    calibration = calibrate_matching(rows, "fibrotic-test-release")
+
+    assert calibration["dataset_version"] == "fibrotic-test-release"
+    assert calibration["methodology"] == {
+        "reference_neighbor_count": 5,
+        "minimum_group_size": 5,
+        "maximum_references": 20,
+        "aggregate_cell_suppression_minimum": 5,
+        "stability_median_overlap_minimum": 0.6,
+        "stability_p10_overlap_minimum": 0.2,
+        "distance_threshold_quantile": 0.95,
+    }
+    target = calibration["targets"]["CKD"]
+    assert target["reference_count"] == 12
+    pattern = target["eligible_patterns"][
+        "blood_pressure|body_composition|demographics|optional_laboratory"
+    ]
+    assert pattern["median_top5_overlap"] >= 0.6
+    assert pattern["p10_top5_overlap"] >= 0.2
+    assert 0 < pattern["distance_threshold"] <= 1
+
+
+@pytest.mark.asyncio
+async def test_match_endpoint_revalidates_confirmed_candidates_and_requires_a_supported_target(
+    api_client,
+):
+    profile = confirmed_profile(candidate("age", 55, source="age 55"))
+    profile["reported_features"]["age"]["normalized_value"] = 90
+    rows = [
+        {
+            "visual_reference_id": f"vr_age_55_{index}",
+            "disease": "CKD",
+            "age_recruit": "55",
+            "sex": "0",
+        }
+        for index in range(5)
+    ]
+    release = {
+        "dataset_version": "fibrotic-test-release",
+        "rows": rows,
+        "calibration": {
+            "methodology": {
+                "minimum_group_size": 5,
+                "maximum_references": 20,
+                "aggregate_cell_suppression_minimum": 5,
+            },
+            "targets": {
+                "CKD": {
+                    "eligible_patterns": {
+                        "demographics": {"distance_threshold": 0.01}
+                    }
+                }
+            },
+        },
+    }
+    app.dependency_overrides[get_profile_matching_release] = lambda: release
+
+    response = await api_client.post(
+        "/profile/match",
+        json={"confirmed_profile": profile, "target": "CKD"},
+    )
+    unsupported = await api_client.post(
+        "/profile/match",
+        json={"confirmed_profile": profile, "target": "Diabetes"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["visual_reference_ids"] == [
+        f"vr_age_55_{index}" for index in range(5)
+    ]
+    assert unsupported.status_code == 422
+
+
+def test_matching_release_requires_exact_private_schema_hash_and_visual_id_mapping(
+    tmp_path,
+):
+    private_path = tmp_path / "private.csv"
+    display_path = tmp_path / "display.csv"
+    manifest_path = tmp_path / "manifest.json"
+    calibration_path = tmp_path / "calibration.json"
+    private_row = {field: "1" for field in MATCH_FIELDS}
+    private_row.update(visual_reference_id="vr_one", disease="CKD")
+    public_row = {field: "1" for field in PUBLIC_FIELDS}
+    public_row.update(visual_reference_id="vr_one", disease="CKD")
+
+    def write_csv(path, fieldnames, row):
+        with path.open("w", newline="") as file:
+            writer = csv.DictWriter(file, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerow(row)
+
+    write_csv(private_path, MATCH_FIELDS, private_row)
+    write_csv(display_path, PUBLIC_FIELDS, public_row)
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "dataset_version": "fibrotic-test-release",
+                "private_schema": MATCH_FIELDS,
+                "private_sha256": hashlib.sha256(private_path.read_bytes()).hexdigest(),
+            }
+        )
+    )
+    calibration_path.write_text(
+        json.dumps(
+            {
+                "dataset_version": "fibrotic-test-release",
+                "methodology": {},
+                "targets": {},
+            }
+        )
+    )
+
+    release = read_matching_release(
+        private_path,
+        display_path,
+        manifest_path,
+        calibration_path,
+    )
+    assert release["rows"][0]["visual_reference_id"] == "vr_one"
+
+    public_row["visual_reference_id"] = "vr_other"
+    write_csv(display_path, PUBLIC_FIELDS, public_row)
+    with pytest.raises(RuntimeError, match="one-to-one"):
+        read_matching_release(
+            private_path,
+            display_path,
+            manifest_path,
+            calibration_path,
+        )

--- a/chatbot/chatbot.css
+++ b/chatbot/chatbot.css
@@ -284,12 +284,65 @@
 }
 
 .chatbot-profile-review,
-.chatbot-profile-confirmed {
+.chatbot-profile-confirmed,
+.chatbot-match-result {
   align-self: stretch;
   max-width: 100%;
   padding: 0.8rem;
   border: 1px solid #bfd0e8;
   background: #f8fafc;
+}
+
+.chatbot-profile-target-label {
+  display: block;
+  margin-top: 0.7rem;
+  color: #273444;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.chatbot-profile-target {
+  width: 100%;
+  margin: 0.25rem 0 0.55rem;
+  padding: 0.42rem 0.5rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 7px;
+  background: #fff;
+  color: #1f2937;
+  font: inherit;
+  font-size: 0.76rem;
+}
+
+.chatbot-match-target,
+.chatbot-match-coverage,
+.chatbot-match-limitations {
+  margin: 0.3rem 0;
+  color: #53606d;
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
+.chatbot-match-domain {
+  margin-top: 0.45rem;
+  padding: 0.45rem 0.55rem;
+  border-left: 3px solid #2c5aa0;
+  background: #edf4fc;
+  color: #334155;
+  font-size: 0.7rem;
+}
+
+.chatbot-match-domain strong {
+  text-transform: capitalize;
+}
+
+.chatbot-match-domain ul {
+  margin: 0.25rem 0 0;
+  padding-left: 1rem;
+}
+
+.chatbot-match-limitations {
+  margin-top: 0.55rem;
+  font-style: italic;
 }
 
 .chatbot-profile-title {
@@ -852,9 +905,28 @@
 
 .quarto-dark .chatbot-profile-starter,
 .quarto-dark .chatbot-profile-review,
-.quarto-dark .chatbot-profile-confirmed {
+.quarto-dark .chatbot-profile-confirmed,
+.quarto-dark .chatbot-match-result {
   border-color: #3d5f8d;
   background: #26323f;
+}
+
+.quarto-dark .chatbot-profile-target {
+  border-color: #56616d;
+  background: #1f252b;
+  color: #edf2f7;
+}
+
+.quarto-dark .chatbot-profile-target-label,
+.quarto-dark .chatbot-match-target,
+.quarto-dark .chatbot-match-coverage,
+.quarto-dark .chatbot-match-limitations {
+  color: #c6d2df;
+}
+
+.quarto-dark .chatbot-match-domain {
+  background: #223a55;
+  color: #dbeafe;
 }
 
 .quarto-dark .chatbot-profile-title,

--- a/chatbot/chatbot.js
+++ b/chatbot/chatbot.js
@@ -29,6 +29,15 @@
       ["false", "No"],
     ],
   };
+  var COMPARISON_TARGETS = [
+    ["CKD", "Chronic Kidney Disease"],
+    ["Cardiac_Fibrosis", "Cardiac Fibrosis"],
+    ["MASH", "MASH"],
+    ["Pulmonary_fibrosis", "Pulmonary Fibrosis"],
+    ["SSc_Connective_Tissue", "Systemic Sclerosis / Connective Tissue"],
+    ["Crohns_Disease", "Crohn's Disease"],
+    ["Fibrosis_of_Skin", "Skin Fibrosis"],
+  ];
 
   var ICON_EXPAND = '<svg viewBox="0 0 24 24"><path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/></svg>';
   var ICON_COLLAPSE = '<svg viewBox="0 0 24 24"><path d="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z"/></svg>';
@@ -105,8 +114,21 @@
 
   // ── State persistence ──
 
+  function syncMessageFormState() {
+    messagesEl.querySelectorAll("input").forEach(function (field) {
+      field.setAttribute("value", field.value);
+    });
+    messagesEl.querySelectorAll("select").forEach(function (field) {
+      Array.from(field.options).forEach(function (option) {
+        if (option.selected) option.setAttribute("selected", "selected");
+        else option.removeAttribute("selected");
+      });
+    });
+  }
+
   function saveState() {
     try {
+      syncMessageFormState();
       sessionStorage.setItem(STORAGE_PREFIX + "history", JSON.stringify(history));
       sessionStorage.setItem(STORAGE_PREFIX + "messages", messagesEl.innerHTML);
       sessionStorage.setItem(STORAGE_PREFIX + "disease", lastAssessedDisease || "");
@@ -201,6 +223,8 @@
     if (action === "start-demo-profile") startDemoProfile();
     if (action === "save-profile-edits") saveProfileEdits(button);
     if (action === "confirm-demo-profile") confirmDemoProfile(button);
+    if (action === "compare-confirmed-profile") compareConfirmedProfile(button);
+    if (action === "view-matched-references") viewMatchedReferences(button);
     if (action === "start-over-demo-profile") startOverDemoProfile();
   });
 
@@ -667,9 +691,10 @@
       .then(function (confirmed) {
         profileSession.confirm(confirmed);
         card.setAttribute("data-profile-current", "0");
-        card.querySelectorAll("input, button").forEach(function (control) {
+        card.querySelectorAll("input, select, button").forEach(function (control) {
           control.disabled = true;
         });
+        status.textContent = "Profile confirmed.";
         renderConfirmedProfile(confirmed);
         updateProfileInputState();
       })
@@ -689,21 +714,220 @@
     title.textContent = "Confirmed Profile";
     var copy = createEl("p", "chatbot-profile-notice");
     copy.textContent =
-      "Your reviewed Demo Profile is confirmed for this tab. No cohort matching or " +
-      "risk endpoint was called, and this is not medical advice or a personal prediction.";
+      "Your reviewed Demo Profile is confirmed for this tab. Matching has not started. " +
+      "Choose one Comparison Target below; this remains a research cohort comparison, " +
+      "not medical advice, diagnosis, prognosis, or a personal outcome prediction.";
     var count = createEl("div", "chatbot-profile-confirmed-count");
     count.textContent =
       Object.keys(confirmed.reported_features || {}).length +
       " reported features; " +
       Object.keys(confirmed.derived_features || {}).length +
       " derived features.";
+    var targetLabel = createEl("label", "chatbot-profile-target-label");
+    targetLabel.textContent = "Comparison Target";
+    var targetSelect = createEl("select", "chatbot-profile-target", {
+      "aria-label": "Comparison Target",
+    });
+    var emptyTarget = createEl("option");
+    emptyTarget.value = "";
+    emptyTarget.textContent = "Choose one target…";
+    targetSelect.appendChild(emptyTarget);
+    COMPARISON_TARGETS.forEach(function (target) {
+      var option = createEl("option");
+      option.value = target[0];
+      option.textContent = target[1];
+      targetSelect.appendChild(option);
+    });
+    var compare = createEl("button", "chatbot-profile-primary", {
+      type: "button",
+      "data-chatbot-action": "compare-confirmed-profile",
+    });
+    compare.textContent = "Compare with reference cohort";
+    var matchStatus = createEl("div", "chatbot-profile-action-status", {
+      "aria-live": "polite",
+    });
     var startOver = createEl("button", "chatbot-profile-link", {
       type: "button",
       "data-chatbot-action": "start-over-demo-profile",
     });
     startOver.textContent = "Start Over";
-    card.append(title, copy, count, startOver);
+    card.append(
+      title,
+      copy,
+      count,
+      targetLabel,
+      targetSelect,
+      compare,
+      matchStatus,
+      startOver,
+    );
     addRawElement(card);
+  }
+
+  function targetLabel(target) {
+    var match = COMPARISON_TARGETS.find(function (candidate) {
+      return candidate[0] === target;
+    });
+    return match ? match[1] : String(target).replace(/_/g, " ");
+  }
+
+  function formatDomain(domain) {
+    return String(domain).replace(/_/g, " ");
+  }
+
+  function renderAggregateDomains(container, aggregate) {
+    if (!aggregate || !Array.isArray(aggregate.domains)) return;
+    aggregate.domains.forEach(function (domain) {
+      var section = createEl("div", "chatbot-match-domain");
+      var heading = createEl("strong");
+      heading.textContent = formatDomain(domain.domain);
+      var list = createEl("ul");
+      domain.metrics.forEach(function (metric) {
+        var item = createEl("li");
+        if (metric.suppressed) {
+          item.textContent = metric.label + ": suppressed because the aggregate cell is too small";
+        } else if (metric.distribution) {
+          item.textContent =
+            metric.label + ": " +
+            metric.distribution.map(function (entry) {
+              return formatDomain(entry.category) + " (n=" + entry.count + ")";
+            }).join(", ");
+        } else {
+          item.textContent =
+            metric.label + ": median " + metric.median +
+            (metric.unit ? " " + metric.unit : "") +
+            "; range " + metric.range[0] + "–" + metric.range[1] +
+            (metric.unit ? " " + metric.unit : "");
+        }
+        list.appendChild(item);
+      });
+      section.append(heading, list);
+      container.appendChild(section);
+    });
+  }
+
+  function renderCohortComparison(result) {
+    var comparison = result.cohort_comparison_result;
+    var card = createEl(
+      "div",
+      "chatbot-msg chatbot-msg-assistant chatbot-match-result",
+      { "data-profile-scope": "active" },
+    );
+    var title = createEl("div", "chatbot-profile-title");
+    title.textContent = "Cohort Comparison Result";
+    var target = createEl("p", "chatbot-match-target");
+    target.textContent = "Target: " + targetLabel(comparison.target);
+    card.append(title, target);
+
+    if (comparison.status === "insufficient_profile_coverage") {
+      var missing = comparison.profile_coverage.recommended_missing_domain;
+      var coverageCopy = createEl("p", "chatbot-profile-notice");
+      coverageCopy.textContent = missing
+        ? "The confirmed profile does not match a calibrated coverage pattern for this target. Add the " +
+          formatDomain(missing) + " domain, then confirm again."
+        : "The confirmed profile does not match a calibrated coverage pattern for this target.";
+      card.appendChild(coverageCopy);
+    } else if (comparison.status === "no_stable_neighborhood") {
+      var emptyCopy = createEl("p", "chatbot-profile-notice");
+      emptyCopy.textContent =
+        "No Stable Neighborhood: fewer than five references satisfied the validated threshold. " +
+        "The system did not force nearest neighbors into the result.";
+      card.appendChild(emptyCopy);
+    } else {
+      var matchedCopy = createEl("p", "chatbot-profile-notice");
+      matchedCopy.textContent =
+        comparison.neighborhood_size +
+        " threshold-qualified reference patients were selected from the confirmed target cohort.";
+      var coverage = createEl("p", "chatbot-match-coverage");
+      coverage.textContent =
+        "Matching domains: " + comparison.matching_domains.map(formatDomain).join(", ") + ".";
+      card.append(matchedCopy, coverage);
+      renderAggregateDomains(card, result.aggregate_callout_data);
+      var limitations = createEl("p", "chatbot-match-limitations");
+      limitations.textContent = comparison.limitations.join(" ");
+      var view = createEl("button", "chatbot-demo-button", {
+        type: "button",
+        "data-chatbot-action": "view-matched-references",
+      });
+      view.textContent = "View matched reference patients";
+      view.setAttribute("data-match-result", JSON.stringify(result));
+      var viewStatus = createEl("div", "chatbot-demo-status", {
+        "aria-live": "polite",
+      });
+      card.append(limitations, view, viewStatus);
+    }
+    var startOver = createEl("button", "chatbot-profile-link", {
+      type: "button",
+      "data-chatbot-action": "start-over-demo-profile",
+    });
+    startOver.textContent = "Start Over";
+    card.appendChild(startOver);
+    addRawElement(card);
+  }
+
+  function compareConfirmedProfile(button) {
+    var state = profileSession.getState();
+    if (state.phase !== "confirmed" || !state.confirmed) return;
+    var card = button.closest(".chatbot-profile-confirmed");
+    var select = card.querySelector(".chatbot-profile-target");
+    var status = card.querySelector(".chatbot-profile-action-status");
+    if (!select.value) {
+      status.textContent = "Choose one Comparison Target before starting the comparison.";
+      select.focus();
+      return;
+    }
+    button.disabled = true;
+    select.disabled = true;
+    status.textContent = "Checking calibrated Profile Coverage and reference distances…";
+    fetch(API_URL + "/profile/match", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        confirmed_profile: state.confirmed,
+        target: select.value,
+      }),
+    })
+      .then(function (response) {
+        if (!response.ok) throw new Error("API returned " + response.status);
+        return response.json();
+      })
+      .then(function (result) {
+        status.textContent = "Comparison complete.";
+        renderCohortComparison(result);
+      })
+      .catch(function (error) {
+        button.disabled = false;
+        select.disabled = false;
+        status.textContent = "The comparison backend is unavailable. Please try again.";
+        console.error("Profile matching error:", error);
+      });
+  }
+
+  function viewMatchedReferences(button) {
+    if (button.disabled) return;
+    var status = button.parentElement.querySelector(".chatbot-demo-status");
+    try {
+      var result = JSON.parse(button.getAttribute("data-match-result"));
+      var request = DEMO.createMatchedRequest(result);
+      DEMO.saveRequest(sessionStorage, request);
+      DEMO.notifyRequest(window, request);
+      var destination = new URL(findUseCaseUrl());
+      var samePage =
+        destination.origin === window.location.origin &&
+        destination.pathname === window.location.pathname;
+      status.textContent = "Opening the exact matched references in the fibrotic walkthrough.";
+      if (samePage) {
+        window.location.hash = destination.hash;
+        button.textContent = "Show matched references again";
+        status.textContent = "Walkthrough started. Replay and reset controls are available below.";
+      } else {
+        window.location.assign(destination.href);
+      }
+    } catch (error) {
+      button.disabled = false;
+      status.textContent = "The visualization request is unavailable. Run the comparison again.";
+      console.error("Matched reference walkthrough error:", error);
+    }
   }
 
   function startOverDemoProfile() {

--- a/chatbot/embedding-demo.js
+++ b/chatbot/embedding-demo.js
@@ -47,6 +47,41 @@
     };
   }
 
+  function createMatchedRequest(result, createdAt) {
+    var comparison = result && result.cohort_comparison_result;
+    var aggregate = result && result.aggregate_callout_data;
+    if (
+      !result ||
+      !result.dataset_version ||
+      !comparison ||
+      comparison.status !== "matched_reference_neighborhood" ||
+      !comparison.target ||
+      !Array.isArray(result.visual_reference_ids) ||
+      !result.visual_reference_ids.length ||
+      !aggregate ||
+      aggregate.reference_count !== result.visual_reference_ids.length
+    ) {
+      throw new Error("Match response is missing the visualization contract");
+    }
+    return {
+      type: "matched_reference_neighborhood",
+      dataset_version: result.dataset_version,
+      target: comparison.target,
+      display_mode: "matched_selection",
+      visual_reference_ids: result.visual_reference_ids.slice(),
+      summary: {
+        reference_count: aggregate.reference_count,
+        title: aggregate.title,
+        description: aggregate.description,
+        domains: Array.isArray(aggregate.domains)
+          ? JSON.parse(JSON.stringify(aggregate.domains))
+          : [],
+      },
+      created_at: createdAt || new Date().toISOString(),
+      consumed: false,
+    };
+  }
+
   function saveRequest(storage, request) {
     storage.setItem(REQUEST_KEY, JSON.stringify(request));
   }
@@ -98,6 +133,7 @@
     REQUEST_KEY: REQUEST_KEY,
     REQUEST_EVENT: REQUEST_EVENT,
     createPresetRequest: createPresetRequest,
+    createMatchedRequest: createMatchedRequest,
     saveRequest: saveRequest,
     notifyRequest: notifyRequest,
     connectRequestConsumer: connectRequestConsumer,

--- a/chatbot/embedding-demo.test.cjs
+++ b/chatbot/embedding-demo.test.cjs
@@ -121,3 +121,51 @@ test("API authority is resolved once for local preview and deployment", () => {
     "https://example.test",
   );
 });
+
+
+test("matched result request stores exact references and aggregate context without profile values", () => {
+  const result = {
+    dataset_version: "fibrotic-2026-07-13-example",
+    cohort_comparison_result: {
+      status: "matched_reference_neighborhood",
+      target: "MASH",
+      neighborhood_size: 2,
+    },
+    visual_reference_ids: ["vr_match_one", "vr_match_two"],
+    aggregate_callout_data: {
+      reference_count: 2,
+      title: "MASH matched reference neighborhood",
+      description: "Aggregate comparison context.",
+      domains: [
+        {
+          domain: "demographics",
+          metrics: [
+            { feature: "age", median: 55, range: [50, 60], unit: "years" },
+          ],
+        },
+      ],
+    },
+  };
+
+  const request = demo.createMatchedRequest(
+    result,
+    "2026-07-13T12:00:00.000Z",
+  );
+
+  assert.deepEqual(Object.keys(request).sort(), [
+    "consumed",
+    "created_at",
+    "dataset_version",
+    "display_mode",
+    "summary",
+    "target",
+    "type",
+    "visual_reference_ids",
+  ]);
+  assert.equal(request.type, "matched_reference_neighborhood");
+  assert.equal(request.display_mode, "matched_selection");
+  assert.deepEqual(request.visual_reference_ids, ["vr_match_one", "vr_match_two"]);
+  assert.equal(request.summary.domains[0].metrics[0].median, 55);
+  assert.equal(JSON.stringify(request).includes("confirmed_profile"), false);
+  assert.equal(JSON.stringify(request).includes("reported_features"), false);
+});

--- a/docs/demo-profile-matching-calibration-2026-07-13.md
+++ b/docs/demo-profile-matching-calibration-2026-07-13.md
@@ -1,0 +1,78 @@
+# Demo Profile Matching Calibration Evidence
+
+**Date:** 2026-07-13
+
+**Dataset Release:** `fibrotic-2026-07-13-9d04ee36876b`
+
+**Private artifact SHA-256:** `518b472187ca66d62ae519ecbef796d7f172d3772211d7837de8ddb0b53874fc`
+
+This note records the implementation parameters generated for issue #26. It
+does not replace the accepted design or ADRs. The values below describe the
+current research reference cohort; they are not clinical thresholds, healthy
+ranges, or prediction-confidence cutoffs.
+
+## Method
+
+Matching uses a domain-balanced Gower-style distance. Feature differences are
+averaged within each available domain, then domain contributions are averaged
+so a domain with more columns does not receive extra weight. The approved
+domains are demographics, body composition, blood pressure, lifestyle, family
+history, and optional laboratory values.
+
+For every Comparison Target and every available-domain pattern:
+
+1. Treat each Reference Patient in turn as a masked query.
+2. Find its five nearest same-target references using the masked pattern.
+3. Compare those five references with the five selected using all six domains.
+4. Retain a pattern only when median top-five overlap is at least `0.60` and
+   the 10th-percentile overlap is at least `0.20`.
+5. Set the distance threshold to the 95th percentile of the leave-one-out
+   fifth-neighbor distance for that retained target/pattern.
+
+At runtime only references at or below that threshold qualify. Results are
+capped at 20. Fewer than five qualifying references produces `No Stable
+Neighborhood`; the service does not fill the result with threshold-failing
+nearest neighbors.
+
+Aggregate callouts use a separately recorded release suppression minimum of
+five. A categorical metric is withheld as a whole when any displayed category
+or missing-value cell falls below that minimum, which prevents reconstruction
+by subtraction. A continuous metric is withheld when fewer than five selected
+references have a compatible value or when its missing-value cell is nonzero
+but below five. Suppression is represented explicitly in both the chatbot card
+and visualization summary; no sparse values or counts are sent in that metric.
+
+## Coverage result
+
+| Comparison Target | Reference rows | Eligible patterns | Minimum calibrated domains |
+|---|---:|---:|---:|
+| Chronic Kidney Disease | 1,500 | 9 | 4 |
+| Cardiac Fibrosis | 379 | 17 | 3 |
+| Crohn's Disease | 826 | 13 | 3 |
+| Skin Fibrosis | 1,500 | 9 | 4 |
+| MASH | 849 | 13 | 4 |
+| Pulmonary Fibrosis | 869 | 10 | 4 |
+| Systemic Sclerosis / Connective Tissue | 87 | 30 | 2 |
+
+The complete per-target/per-pattern evidence and thresholds are tracked in
+`chatbot-backend/data/fibrotic_matching_calibration.json`.
+
+## Reproduction
+
+The backend-only artifact must be generated in the same preprocessing run as
+the public display artifact. It remains ignored by Git and must be provisioned
+to the Hugging Face backend; matching returns an explicit unavailable response
+when it is absent or fails integrity validation.
+
+```bash
+python chatbot-backend/calibrate_profile_matching.py \
+  --private-artifact chatbot-backend/data/private/fibrotic_match.csv \
+  --manifest chatbot-backend/data/fibrotic_release/fibrotic_manifest.json \
+  --output chatbot-backend/data/fibrotic_matching_calibration.json
+```
+
+Runtime loading verifies the private schema, private SHA-256, calibration
+Dataset Release version, unique Visual Reference IDs, and the one-to-one ID
+mapping to the display-safe embedding. Matching never consumes t-SNE
+coordinates, display groups, `p_true`, model correctness, or source participant
+identifiers.

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -535,6 +535,26 @@ figcaption {
   font-weight: 700;
 }
 
+.embedding-summary-domain {
+  margin-top: 0.65rem;
+  padding-top: 0.55rem;
+  border-top: 1px solid #d9e4f2;
+}
+
+.embedding-summary-domain h4 {
+  margin: 0;
+  color: #2c3e50;
+  font-size: 0.76rem;
+  text-transform: capitalize;
+}
+
+.embedding-summary-domain ul {
+  margin: 0.25rem 0 0;
+  padding-left: 1.1rem;
+  color: #495057;
+  font-size: 0.76rem;
+}
+
 .embedding-summary-note {
   color: #6c757d;
   font-style: italic;
@@ -607,8 +627,17 @@ figcaption {
 }
 
 .quarto-dark .embedding-summary h3,
-.quarto-dark .embedding-summary dd {
+.quarto-dark .embedding-summary dd,
+.quarto-dark .embedding-summary-domain h4 {
   color: #e5edf5;
+}
+
+.quarto-dark .embedding-summary-domain {
+  border-top-color: #3f5067;
+}
+
+.quarto-dark .embedding-summary-domain ul {
+  color: #c4d0dc;
 }
 
 .quarto-dark .embedding-summary-kicker {

--- a/viz/embedding-scatter.js
+++ b/viz/embedding-scatter.js
@@ -39,6 +39,22 @@ export function walkthroughFocusIndices(displayMode, allIndices, selectedIndices
 }
 
 
+export function walkthroughCopy(request) {
+  if (request?.type === "matched_reference_neighborhood") {
+    return {
+      kicker: "Matched reference neighborhood",
+      pointNoun: "matched reference points",
+      note: "Research cohort comparison only; no query patient is embedded and no diagnosis, prognosis, or personal outcome is inferred.",
+    };
+  }
+  return {
+    kicker: "Preset reference selection",
+    pointNoun: "preset reference points",
+    note: "Display preset only; no query patient is embedded and no clinical comparison or personal outcome is inferred.",
+  };
+}
+
+
 export function createRunController() {
   let currentToken = 0;
   return {
@@ -148,7 +164,7 @@ export async function createEmbeddingScatter(config) {
   status.className = "embedding-status";
   status.setAttribute("aria-live", "polite");
   status.textContent = "Overview · waiting for a walkthrough request";
-  const playButton = button("Play preset walkthrough", "embedding-button embedding-button-primary");
+  const playButton = button("Play walkthrough", "embedding-button embedding-button-primary");
   const replayButton = button("Replay");
   const resetButton = button("Reset view");
   replayButton.hidden = true;
@@ -233,12 +249,13 @@ export async function createEmbeddingScatter(config) {
   }
 
   function showCallout(request) {
+    const copy = walkthroughCopy(request);
     region.classList.toggle("is-visible", request.display_mode === "compact");
     summary.hidden = false;
     summary.replaceChildren();
     const kicker = document.createElement("div");
     kicker.className = "embedding-summary-kicker";
-    kicker.textContent = "Preset reference selection";
+    kicker.textContent = copy.kicker;
     const title = document.createElement("h3");
     title.textContent = request.summary.title;
     const description = document.createElement("p");
@@ -261,6 +278,32 @@ export async function createEmbeddingScatter(config) {
     note.textContent =
       "Display preset only; no query patient is embedded and no clinical similarity or personal outcome is inferred.";
     summary.append(kicker, title, description, details, note);
+    if (Array.isArray(request.summary.domains)) {
+      request.summary.domains.forEach((domain) => {
+        const domainSection = document.createElement("section");
+        domainSection.className = "embedding-summary-domain";
+        const domainTitle = document.createElement("h4");
+        domainTitle.textContent = String(domain.domain).replaceAll("_", " ");
+        const list = document.createElement("ul");
+        domain.metrics.forEach((metric) => {
+          const item = document.createElement("li");
+          if (metric.suppressed) {
+            item.textContent = `${metric.label}: suppressed because the aggregate cell is too small`;
+          } else if (metric.distribution) {
+            item.textContent = `${metric.label}: ${metric.distribution
+              .map((entry) => `${String(entry.category).replaceAll("_", " ")} (n=${entry.count})`)
+              .join(", ")}`;
+          } else {
+            const unit = metric.unit ? ` ${metric.unit}` : "";
+            item.textContent = `${metric.label}: median ${metric.median}${unit}; range ${metric.range[0]}–${metric.range[1]}${unit}`;
+          }
+          list.appendChild(item);
+        });
+        domainSection.append(domainTitle, list);
+        summary.insertBefore(domainSection, note);
+      });
+    }
+    note.textContent = copy.note;
     status.textContent = `Walkthrough complete · ${request.summary.reference_count} reference points highlighted`;
     replayButton.hidden = false;
     playButton.hidden = true;
@@ -287,7 +330,7 @@ export async function createEmbeddingScatter(config) {
         await drawDimmed();
         await delay(420);
       } else if (stage === "highlight") {
-        status.textContent = `${animate ? "Highlighting" : "Showing"} ${indices.length} preset reference points`;
+        status.textContent = `${animate ? "Highlighting" : "Showing"} ${indices.length} ${walkthroughCopy(request).pointNoun}`;
         await drawHighlighted(indices);
         if (animate) await delay(420);
       } else if (stage === "zoom") {
@@ -298,7 +341,9 @@ export async function createEmbeddingScatter(config) {
         );
         status.textContent = request.display_mode === "overview"
           ? "Keeping the dispersed selection in the full embedding overview"
-          : "Zooming to the display region";
+          : request.display_mode === "matched_selection"
+            ? "Fitting the exact matched reference selection"
+            : "Zooming to the display region";
         await scatterplot.zoomToPoints(focusIndices, {
           padding: request.display_mode === "overview" ? 0.08 : 0.25,
           transition: animate,
@@ -324,7 +369,7 @@ export async function createEmbeddingScatter(config) {
     playButton.disabled = false;
     replayButton.disabled = false;
     resetButton.disabled = false;
-    status.textContent = "Overview · preset walkthrough ready";
+    status.textContent = "Overview · walkthrough ready";
     await drawOverview();
     await scatterplot.zoomToPoints(allIndices, { padding: 0.08 });
   }

--- a/viz/embedding-scatter.test.mjs
+++ b/viz/embedding-scatter.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 import test from "node:test";
 
 import {
@@ -6,9 +7,13 @@ import {
   createRunController,
   normalizePoints,
   resolveReferenceIndices,
+  walkthroughCopy,
   walkthroughFocusIndices,
   walkthroughPlan,
 } from "./embedding-scatter.js";
+
+const require = createRequire(import.meta.url);
+const demo = require("../chatbot/embedding-demo.js");
 
 
 test("normalization preserves aspect ratio inside WebGL coordinates", () => {
@@ -98,4 +103,67 @@ test("production control binding routes play, replay, and reset", () => {
     ["play", request],
     ["reset"],
   ]);
+});
+
+
+test("walkthrough copy distinguishes a live match from a fixed preset", () => {
+  assert.deepEqual(
+    walkthroughCopy({ type: "matched_reference_neighborhood" }),
+    {
+      kicker: "Matched reference neighborhood",
+      pointNoun: "matched reference points",
+      note: "Research cohort comparison only; no query patient is embedded and no diagnosis, prognosis, or personal outcome is inferred.",
+    },
+  );
+  assert.equal(
+    walkthroughCopy({ type: "preset_selection" }).kicker,
+    "Preset reference selection",
+  );
+});
+
+
+test("live match crosses session request boundary and focuses exact graph references", () => {
+  const values = new Map();
+  const storage = {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+    removeItem: (key) => values.delete(key),
+  };
+  const result = {
+    dataset_version: "fibrotic-test-release",
+    cohort_comparison_result: {
+      status: "matched_reference_neighborhood",
+      target: "MASH",
+    },
+    visual_reference_ids: ["vr_match_two", "vr_match_one"],
+    aggregate_callout_data: {
+      reference_count: 2,
+      title: "Matched reference neighborhood",
+      description: "Aggregate context.",
+      domains: [],
+    },
+  };
+  const data = [
+    { visual_reference_id: "vr_other" },
+    { visual_reference_id: "vr_match_one" },
+    { visual_reference_id: "vr_match_two" },
+  ];
+
+  demo.saveRequest(
+    storage,
+    demo.createMatchedRequest(result, "2026-07-13T12:00:00Z"),
+  );
+  const consumed = demo.consumeRequest(storage, "fibrotic-test-release");
+  const selected = resolveReferenceIndices(
+    data,
+    consumed.request.visual_reference_ids,
+  );
+
+  assert.equal(consumed.should_play, true);
+  assert.equal(consumed.request.display_mode, "matched_selection");
+  assert.deepEqual(selected, [2, 1]);
+  assert.deepEqual(
+    walkthroughFocusIndices("matched_selection", [0, 1, 2], selected),
+    [2, 1],
+  );
 });

--- a/viz/use-case.qmd
+++ b/viz/use-case.qmd
@@ -16,7 +16,7 @@ This page demonstrates the clinical utility of ALIGATEHR-Gen through a focused c
 
 ## Patient Embeddings — 7 Fibrotic Diseases {#fibrotic-embedding}
 
-The plot below loads its display-safe reference points from the same backend Dataset Release used by the walkthrough. It contains no source participant IDs or individual clinical profiles.
+The plot below loads its display-safe reference points from the same backend Dataset Release used by preset and confirmed Demo Profile walkthroughs. It contains no source participant IDs or individual clinical profiles.
 
 ```{ojs}
 //| echo: false


### PR DESCRIPTION
## Summary

Implements #26 as a stacked change on #32.

- adds deterministic, target-scoped, domain-balanced Gower-style matching for Confirmed Demo Profiles
- calibrates eligible coverage patterns and per-target adaptive thresholds from leave-one-out neighborhood masking evidence
- caps successful neighborhoods at 20, preserves honest insufficient-coverage and no-stable-neighborhood states, and never uses t-SNE coordinates or outcome fields for matching
- returns Cohort Comparison Result, exact Visual Reference IDs, and release-controlled aggregate callout data as separate response fields
- suppresses categorical or continuous aggregate cells below the release suppression minimum
- connects the explicit chatbot CTA to the existing live WebGL walkthrough, where the consumer resolves and focuses the exact returned references
- keeps personal risk scores, diagnosis, prognosis, similarity percentages, and Query Patient embedding out of the flow
- records calibration methodology, coverage evidence, artifact integrity, suppression behavior, and backend provisioning requirements

## Context

This PR is intentionally based on `codex/issue-25-demo-profile` while #32 remains open. Retarget to `main` after #31 and #32 merge.

Authoritative context:

- [accepted design at 79b16b4](https://github.com/PatrickTangwen/report-web/blob/79b16b4ebf5add5dd8eeb81edab83cc30dcba136/docs/chatbot-embedding-visualization-design-2026-07-13.md)
- [project terminology](https://github.com/PatrickTangwen/report-web/blob/79b16b4ebf5add5dd8eeb81edab83cc30dcba136/CONTEXT.md)
- [ADR 0002](https://github.com/PatrickTangwen/report-web/blob/79b16b4ebf5add5dd8eeb81edab83cc30dcba136/docs/adr/0002-show-aggregate-neighborhood-callouts.md)
- [ADR 0004](https://github.com/PatrickTangwen/report-web/blob/79b16b4ebf5add5dd8eeb81edab83cc30dcba136/docs/adr/0004-do-not-infer-risk-from-neighbor-outcomes.md)

## Deployment prerequisite

The private matching artifact remains ignored by Git. It must be provisioned to the Hugging Face backend at `chatbot-backend/data/private/fibrotic_match.csv`. Runtime loading rejects a missing artifact, schema drift, SHA mismatch, calibration-version mismatch, or a non-bijective Visual Reference ID mapping rather than falling back to stale or public data.

## Validation

- `python -m pytest -q chatbot-backend` — 107 passed
- `node --test chatbot/*.test.cjs` — 11 passed
- `node --test viz/*.test.mjs` — 8 passed
- `node --check` on changed JavaScript — passed
- `python -m compileall -q chatbot-backend` — passed
- `python scripts/check_ojs_assets.py` — passed
- `quarto render` — passed; existing unresolved `viz/dashboard.qmd` warning unchanged
- real local browser smoke — warning → extract → edit/confirm → select target → live match → explicit CTA → exact 20-reference WebGL highlight → Replay/Reset; no browser console errors and no `/assess` request
- cross-surface consumer test — exact live-match IDs resolve in the active release and become the walkthrough camera focus
- final two-axis review — no blocking Standards or Spec findings
