### PR TITLE
Support partial profiles and honest edge states

### DIFF
--- a/chatbot-backend/fibrotic_release.py
+++ b/chatbot-backend/fibrotic_release.py
@@ -42,6 +42,11 @@ def load_fibrotic_release():
         raise RuntimeError("Fibrotic preset and display release versions differ")
     if preset.get("display_mode") not in {"compact", "multi_region", "overview"}:
         raise RuntimeError("Fibrotic preset has an unsupported display mode")
+    if preset["display_mode"] == "multi_region" and not (
+        isinstance(preset.get("minimum_region_size"), int)
+        and preset["minimum_region_size"] >= 1
+    ):
+        raise RuntimeError("Multi-region preset is missing its geometry contract")
     if not set(preset["visual_reference_ids"]) <= point_ids:
         raise RuntimeError("Fibrotic preset references points outside the release")
 

--- a/chatbot-backend/profile_matching.py
+++ b/chatbot-backend/profile_matching.py
@@ -58,6 +58,14 @@ DOMAIN_FEATURES = {
         ("hba1c", "HbA1c", "continuous"),
     ),
 }
+DOMAIN_MEASUREMENTS = {
+    "demographics": ["age", "sex when supplied"],
+    "body_composition": ["height and weight", "BMI", "waist and hip circumference"],
+    "blood_pressure": ["systolic and diastolic blood pressure"],
+    "lifestyle": ["smoking status", "alcohol frequency"],
+    "family_history": ["affected-relative status"],
+    "optional_laboratory": ["creatinine", "HbA1c"],
+}
 FEATURE_PRESENTATION = {
     "age": ("Age", "years"),
     "bmi": ("BMI", "kg/m²"),
@@ -139,6 +147,17 @@ def _profile_values(confirmed_profile):
         if feature and feature.get("status") in {"valid", "outside_reference_support"}:
             values[field] = feature.get("value")
     return values
+
+
+def _outside_reference_support_domains(confirmed_profile):
+    domains = set()
+    for section in ("reported_features", "derived_features"):
+        for feature in confirmed_profile.get(section, {}).values():
+            if feature.get("status") == "outside_reference_support" and feature.get(
+                "domain"
+            ) in DOMAIN_FEATURES:
+                domains.add(feature["domain"])
+    return [domain for domain in DOMAIN_FEATURES if domain in domains]
 
 
 def _row_value(row, row_field):
@@ -261,7 +280,7 @@ def _aggregate_callout(profile_values, selected_rows, suppression_minimum):
     }
 
 
-def _recommended_missing_domain(available_domains, eligible_patterns):
+def _coverage_recommendation(available_domains, eligible_patterns):
     available = set(available_domains)
     candidates = []
     for pattern, evidence in eligible_patterns.items():
@@ -269,17 +288,28 @@ def _recommended_missing_domain(available_domains, eligible_patterns):
         if not available <= domains:
             continue
         missing = domains - available
-        if len(missing) != 1:
+        if not missing:
             continue
         candidates.append(
             (
+                len(missing),
                 -evidence.get("p10_top5_overlap", 0),
                 -evidence.get("median_top5_overlap", 0),
                 pattern,
-                missing.pop(),
+                missing,
             )
         )
-    return min(candidates)[3] if candidates else None
+    if not candidates:
+        return None
+    _, _, _, pattern, missing = min(candidates)
+    ordered_missing = [domain for domain in DOMAIN_FEATURES if domain in missing]
+    return {
+        "calibration_pattern": pattern,
+        "missing_domains": ordered_missing,
+        "measurements_by_domain": {
+            domain: DOMAIN_MEASUREMENTS[domain] for domain in ordered_missing
+        },
+    }
 
 
 def match_confirmed_profile(confirmed_profile, target, rows, calibration, dataset_version):
@@ -290,14 +320,29 @@ def match_confirmed_profile(confirmed_profile, target, rows, calibration, datase
         if any(feature[0] in values for feature in features)
     ]
     pattern = "|".join(sorted(available_domains))
+    outside_support_domains = _outside_reference_support_domains(confirmed_profile)
+    unavailable_domains = [
+        domain for domain in DOMAIN_FEATURES if domain not in available_domains
+    ]
     target_calibration = calibration.get("targets", {}).get(target, {})
     eligible_patterns = target_calibration.get("eligible_patterns", {})
     pattern_calibration = eligible_patterns.get(pattern)
     if not pattern_calibration:
-        profile_coverage = {"available_domains": available_domains, "eligible": False}
-        recommended = _recommended_missing_domain(available_domains, eligible_patterns)
-        if recommended:
-            profile_coverage["recommended_missing_domain"] = recommended
+        profile_coverage = {
+            "available_domains": available_domains,
+            "unavailable_domains": unavailable_domains,
+            "eligible": False,
+        }
+        if outside_support_domains:
+            profile_coverage["outside_reference_support_domains"] = (
+                outside_support_domains
+            )
+        recommendation = _coverage_recommendation(
+            available_domains,
+            eligible_patterns,
+        )
+        if recommendation:
+            profile_coverage["coverage_recommendation"] = recommendation
         return {
             "dataset_version": dataset_version,
             "cohort_comparison_result": {
@@ -329,18 +374,34 @@ def match_confirmed_profile(confirmed_profile, target, rows, calibration, datase
     )
     if status == "no_stable_neighborhood":
         visual_reference_ids = []
+    profile_coverage = {
+        "available_domains": available_domains,
+        "unavailable_domains": unavailable_domains,
+        "eligible": True,
+        "calibration_pattern": pattern,
+    }
+    if outside_support_domains:
+        profile_coverage["outside_reference_support_domains"] = (
+            outside_support_domains
+        )
+    masking_stability = {
+        key: pattern_calibration[key]
+        for key in ("median_top5_overlap", "p10_top5_overlap")
+        if key in pattern_calibration
+    }
+    if masking_stability:
+        profile_coverage["masking_stability"] = masking_stability
     return {
         "dataset_version": dataset_version,
         "cohort_comparison_result": {
             "status": status,
             "target": target,
-            "profile_coverage": {
-                "available_domains": available_domains,
-                "eligible": True,
-                "calibration_pattern": pattern,
-            },
+            "profile_coverage": profile_coverage,
             "matching_domains": available_domains,
             "neighborhood_size": len(visual_reference_ids),
+            "minimum_display_region_size": calibration["methodology"][
+                "aggregate_cell_suppression_minimum"
+            ],
             "limitations": [
                 "Research cohort comparison only; the Demo Profile is not embedded and no diagnosis, prognosis, or personal outcome is inferred."
             ],

--- a/chatbot-backend/test_profile_matching.py
+++ b/chatbot-backend/test_profile_matching.py
@@ -248,11 +248,19 @@ def test_adaptive_neighborhood_caps_at_twenty_and_keeps_callouts_aggregate_only(
         "target": "CKD",
         "profile_coverage": {
             "available_domains": ["demographics"],
+            "unavailable_domains": [
+                "body_composition",
+                "blood_pressure",
+                "lifestyle",
+                "family_history",
+                "optional_laboratory",
+            ],
             "eligible": True,
             "calibration_pattern": "demographics",
         },
         "matching_domains": ["demographics"],
         "neighborhood_size": 20,
+        "minimum_display_region_size": 5,
         "limitations": [
             "Research cohort comparison only; the Demo Profile is not embedded and no diagnosis, prognosis, or personal outcome is inferred."
         ],
@@ -376,11 +384,136 @@ def test_insufficient_coverage_requests_the_nearest_calibrated_missing_domain():
     assert comparison["status"] == "insufficient_profile_coverage"
     assert comparison["profile_coverage"] == {
         "available_domains": ["demographics"],
+        "unavailable_domains": [
+            "body_composition",
+            "blood_pressure",
+            "lifestyle",
+            "family_history",
+            "optional_laboratory",
+        ],
         "eligible": False,
-        "recommended_missing_domain": "lifestyle",
+        "coverage_recommendation": {
+            "calibration_pattern": "demographics|lifestyle",
+            "missing_domains": ["lifestyle"],
+            "measurements_by_domain": {
+                "lifestyle": ["smoking status", "alcohol frequency"]
+            },
+        },
     }
     assert result["visual_reference_ids"] == []
     assert result["aggregate_callout_data"] is None
+
+
+def test_insufficient_coverage_recommends_the_nearest_complete_calibrated_pattern():
+    profile = confirmed_profile(candidate("age", 55, source="age 55"))
+    calibration = {
+        "methodology": {
+            "minimum_group_size": 5,
+            "maximum_references": 20,
+            "aggregate_cell_suppression_minimum": 5,
+        },
+        "targets": {
+            "CKD": {
+                "eligible_patterns": {
+                    "blood_pressure|body_composition|demographics|lifestyle": {
+                        "distance_threshold": 0.1,
+                        "median_top5_overlap": 0.6,
+                        "p10_top5_overlap": 0.2,
+                    },
+                    "blood_pressure|body_composition|demographics|family_history|lifestyle": {
+                        "distance_threshold": 0.1,
+                        "median_top5_overlap": 0.8,
+                        "p10_top5_overlap": 0.6,
+                    },
+                }
+            }
+        },
+    }
+
+    result = match_confirmed_profile(
+        profile,
+        "CKD",
+        [],
+        calibration,
+        "fibrotic-test-release",
+    )
+
+    recommendation = result["cohort_comparison_result"]["profile_coverage"][
+        "coverage_recommendation"
+    ]
+    assert recommendation["calibration_pattern"] == (
+        "blood_pressure|body_composition|demographics|lifestyle"
+    )
+    assert recommendation["missing_domains"] == [
+        "body_composition",
+        "blood_pressure",
+        "lifestyle",
+    ]
+
+
+def test_eligible_partial_profile_reports_only_calibrated_available_domains():
+    profile = confirmed_profile(
+        candidate("age", 55, source="age 55"),
+        candidate("smoking_status", "former", source="former smoker"),
+    )
+    rows = [
+        {
+            "visual_reference_id": f"vr_{index}",
+            "disease": "MASH",
+            "age_recruit": "55",
+            "smoking_status": "1",
+            "creatinine": "100",
+        }
+        for index in range(5)
+    ]
+    calibration = {
+        "methodology": {
+            "minimum_group_size": 5,
+            "maximum_references": 20,
+            "aggregate_cell_suppression_minimum": 5,
+        },
+        "targets": {
+            "MASH": {
+                "eligible_patterns": {
+                    "demographics|lifestyle": {
+                        "distance_threshold": 0.1,
+                        "median_top5_overlap": 0.8,
+                        "p10_top5_overlap": 0.4,
+                    }
+                }
+            }
+        },
+    }
+
+    result = match_confirmed_profile(
+        profile,
+        "MASH",
+        rows,
+        calibration,
+        "fibrotic-test-release",
+    )
+
+    comparison = result["cohort_comparison_result"]
+    assert comparison["profile_coverage"] == {
+        "available_domains": ["demographics", "lifestyle"],
+        "unavailable_domains": [
+            "body_composition",
+            "blood_pressure",
+            "family_history",
+            "optional_laboratory",
+        ],
+        "eligible": True,
+        "calibration_pattern": "demographics|lifestyle",
+        "masking_stability": {
+            "median_top5_overlap": 0.8,
+            "p10_top5_overlap": 0.4,
+        },
+    }
+    assert comparison["matching_domains"] == ["demographics", "lifestyle"]
+    assert comparison["minimum_display_region_size"] == 5
+    assert [
+        domain["domain"] for domain in result["aggregate_callout_data"]["domains"]
+    ] == ["demographics", "lifestyle"]
 
 
 def test_threshold_failure_returns_no_stable_neighborhood_without_forced_neighbors():
@@ -421,6 +554,48 @@ def test_threshold_failure_returns_no_stable_neighborhood_without_forced_neighbo
     assert result["cohort_comparison_result"]["neighborhood_size"] == 0
     assert result["visual_reference_ids"] == []
     assert result["aggregate_callout_data"] is None
+
+
+def test_outside_reference_support_is_preserved_as_an_honest_edge_state():
+    profile = confirmed_profile(candidate("age", 32, source="age 32"))
+    rows = [
+        {
+            "visual_reference_id": f"vr_{index}",
+            "disease": "CKD",
+            "age_recruit": "33",
+            "sex": "0",
+        }
+        for index in range(5)
+    ]
+    calibration = {
+        "methodology": {
+            "minimum_group_size": 5,
+            "maximum_references": 20,
+            "aggregate_cell_suppression_minimum": 5,
+        },
+        "targets": {
+            "CKD": {
+                "eligible_patterns": {
+                    "demographics": {"distance_threshold": 0.001}
+                }
+            }
+        },
+    }
+
+    result = match_confirmed_profile(
+        profile,
+        "CKD",
+        rows,
+        calibration,
+        "fibrotic-test-release",
+    )
+
+    comparison = result["cohort_comparison_result"]
+    assert comparison["status"] == "no_stable_neighborhood"
+    assert comparison["profile_coverage"]["outside_reference_support_domains"] == [
+        "demographics"
+    ]
+    assert result["visual_reference_ids"] == []
 
 
 def test_calibration_records_masking_stability_and_fifth_neighbor_thresholds():

--- a/chatbot/chatbot.css
+++ b/chatbot/chatbot.css
@@ -293,6 +293,47 @@
   background: #f8fafc;
 }
 
+.chatbot-match-result.is-coverage-needed {
+  border-color: #c4871d;
+  background: #fff9ed;
+}
+
+.chatbot-match-result.is-no-result {
+  border-color: #a64b4b;
+  background: #fff5f5;
+}
+
+.chatbot-match-result.is-matched {
+  border-color: #438866;
+  background: #f3faf6;
+}
+
+.chatbot-result-status {
+  display: inline-block;
+  margin: 0.15rem 0 0.25rem;
+  padding: 0.18rem 0.42rem;
+  border-radius: 999px;
+  background: #e7edf5;
+  color: #273444;
+  font-size: 0.67rem;
+  font-weight: 750;
+}
+
+.is-coverage-needed .chatbot-result-status {
+  background: #f8e5b9;
+  color: #6d4600;
+}
+
+.is-no-result .chatbot-result-status {
+  background: #f5d5d5;
+  color: #772b2b;
+}
+
+.is-matched .chatbot-result-status {
+  background: #d7eee0;
+  color: #245b3d;
+}
+
 .chatbot-profile-target-label {
   display: block;
   margin-top: 0.7rem;
@@ -909,6 +950,41 @@
 .quarto-dark .chatbot-match-result {
   border-color: #3d5f8d;
   background: #26323f;
+}
+
+.quarto-dark .chatbot-match-result.is-coverage-needed {
+  border-color: #b88733;
+  background: #3b3223;
+}
+
+.quarto-dark .chatbot-match-result.is-no-result {
+  border-color: #b26161;
+  background: #3b292c;
+}
+
+.quarto-dark .chatbot-match-result.is-matched {
+  border-color: #4f9270;
+  background: #24372e;
+}
+
+.quarto-dark .chatbot-result-status {
+  background: #394657;
+  color: #e5edf5;
+}
+
+.quarto-dark .is-coverage-needed .chatbot-result-status {
+  background: #5a4726;
+  color: #f8dba0;
+}
+
+.quarto-dark .is-no-result .chatbot-result-status {
+  background: #5a3035;
+  color: #f5c3c8;
+}
+
+.quarto-dark .is-matched .chatbot-result-status {
+  background: #2d5741;
+  color: #c7efd7;
 }
 
 .quarto-dark .chatbot-profile-target {

--- a/chatbot/chatbot.js
+++ b/chatbot/chatbot.js
@@ -6,6 +6,7 @@
   var API_URL = DEMO.resolveApiUrl(window.location, window.ALIGATEHR_API_URL);
   var STORAGE_PREFIX = "aligatehr-chatbot-";
   var profileSession = PROFILE.create(sessionStorage);
+  var profileMatchController = DEMO.createRequestController();
   var PROFILE_CHOICES = {
     sex: [
       ["female", "Female"],
@@ -328,13 +329,18 @@
     button.disabled = true;
     button.textContent = "Preparing demo…";
     status.textContent = "Loading the current dataset release.";
+    var coldStartNotice = setTimeout(function () {
+      status.textContent = "The backend is still waking from a cold start. You remain in control and can retry if it times out.";
+    }, 4000);
 
-    fetch(API_URL + "/embedding/fibrotic/preset", { cache: "no-store" })
-      .then(function (response) {
-        if (!response.ok) throw new Error("API returned " + response.status);
-        return response.json();
-      })
+    DEMO.requestJson(
+      fetch,
+      API_URL + "/embedding/fibrotic/preset",
+      { cache: "no-store" },
+      30000,
+    )
       .then(function (preset) {
+        clearTimeout(coldStartNotice);
         var request = DEMO.createPresetRequest(preset);
         DEMO.saveRequest(sessionStorage, request);
         DEMO.notifyRequest(window, request);
@@ -354,6 +360,7 @@
         }
       })
       .catch(function (error) {
+        clearTimeout(coldStartNotice);
         button.disabled = false;
         button.textContent = "Try animated demo";
         status.textContent = "The demo backend is unavailable. Please try again.";
@@ -808,6 +815,7 @@
 
   function renderCohortComparison(result) {
     var comparison = result.cohort_comparison_result;
+    var coverage = comparison.profile_coverage || {};
     var card = createEl(
       "div",
       "chatbot-msg chatbot-msg-assistant chatbot-match-result",
@@ -817,31 +825,64 @@
     title.textContent = "Cohort Comparison Result";
     var target = createEl("p", "chatbot-match-target");
     target.textContent = "Target: " + targetLabel(comparison.target);
-    card.append(title, target);
+    var presentation = {
+      insufficient_profile_coverage: ["Coverage needed", "is-coverage-needed"],
+      no_stable_neighborhood: ["No stable neighborhood", "is-no-result"],
+      matched_reference_neighborhood: ["Matched neighborhood", "is-matched"],
+    }[comparison.status] || ["Comparison status", "is-no-result"];
+    card.classList.add(presentation[1]);
+    var resultStatus = createEl("div", "chatbot-result-status");
+    resultStatus.textContent = presentation[0];
+    var coverageDetails = createEl("p", "chatbot-match-coverage");
+    var availableDomains = coverage.available_domains || [];
+    var unavailableDomains = coverage.unavailable_domains || [];
+    coverageDetails.textContent =
+      "Profile Coverage — available domains: " +
+      (availableDomains.length ? availableDomains.map(formatDomain).join(", ") : "none") +
+      "; unavailable domains: " +
+      (unavailableDomains.length ? unavailableDomains.map(formatDomain).join(", ") : "none") +
+      ". Missing domains were not imputed or treated as matches.";
+    var outsideSupport = coverage.outside_reference_support_domains || [];
+    if (outsideSupport.length) {
+      coverageDetails.textContent +=
+        " Values in these domains were outside this cohort's reference support and were preserved without clamping: " +
+        outsideSupport.map(formatDomain).join(", ") + ".";
+    }
+    card.append(title, target, resultStatus, coverageDetails);
 
     if (comparison.status === "insufficient_profile_coverage") {
-      var missing = comparison.profile_coverage.recommended_missing_domain;
+      var recommendation = coverage.coverage_recommendation;
       var coverageCopy = createEl("p", "chatbot-profile-notice");
-      coverageCopy.textContent = missing
-        ? "The confirmed profile does not match a calibrated coverage pattern for this target. Add the " +
-          formatDomain(missing) + " domain, then confirm again."
+      var recommendationCopy = recommendation
+        ? recommendation.missing_domains.map(function (domain) {
+            var measurements = recommendation.measurements_by_domain[domain] || [];
+            return formatDomain(domain) +
+              (measurements.length ? " (for example, " + measurements.join(" or ") + ")" : "");
+          }).join("; ")
+        : "";
+      coverageCopy.textContent = recommendation
+        ? "The confirmed profile does not match a calibrated coverage pattern for this target. " +
+          "To reach the nearest complete calibrated pattern, add: " + recommendationCopy +
+          ". Missing fields were not treated as matches."
         : "The confirmed profile does not match a calibrated coverage pattern for this target.";
       card.appendChild(coverageCopy);
     } else if (comparison.status === "no_stable_neighborhood") {
       var emptyCopy = createEl("p", "chatbot-profile-notice");
       emptyCopy.textContent =
         "No Stable Neighborhood: fewer than five references satisfied the validated threshold. " +
-        "The system did not force nearest neighbors into the result.";
+        "The system did not force nearest neighbors into the result. This does not mean " +
+        "comparable people do not exist outside this research cohort." +
+        (outsideSupport.length
+          ? " Confirmed values in the " + outsideSupport.map(formatDomain).join(", ") +
+            " domain were outside this cohort's reference support and were preserved without clamping."
+          : "");
       card.appendChild(emptyCopy);
     } else {
       var matchedCopy = createEl("p", "chatbot-profile-notice");
       matchedCopy.textContent =
         comparison.neighborhood_size +
         " threshold-qualified reference patients were selected from the confirmed target cohort.";
-      var coverage = createEl("p", "chatbot-match-coverage");
-      coverage.textContent =
-        "Matching domains: " + comparison.matching_domains.map(formatDomain).join(", ") + ".";
-      card.append(matchedCopy, coverage);
+      card.appendChild(matchedCopy);
       renderAggregateDomains(card, result.aggregate_callout_data);
       var limitations = createEl("p", "chatbot-match-limitations");
       limitations.textContent = comparison.limitations.join(" ");
@@ -879,26 +920,40 @@
     button.disabled = true;
     select.disabled = true;
     status.textContent = "Checking calibrated Profile Coverage and reference distances…";
-    fetch(API_URL + "/profile/match", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        confirmed_profile: state.confirmed,
-        target: select.value,
-      }),
-    })
-      .then(function (response) {
-        if (!response.ok) throw new Error("API returned " + response.status);
-        return response.json();
-      })
+    var run = profileMatchController.start();
+    var coldStartNotice = setTimeout(function () {
+      if (profileMatchController.isCurrent(run.token)) {
+        status.textContent = "The backend is still waking from a cold start. This request will time out with a Retry option rather than using stale results.";
+      }
+    }, 4000);
+    DEMO.requestJson(
+      fetch,
+      API_URL + "/profile/match",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          confirmed_profile: state.confirmed,
+          target: select.value,
+        }),
+        signal: run.signal,
+      },
+      30000,
+    )
       .then(function (result) {
+        clearTimeout(coldStartNotice);
+        if (!profileMatchController.isCurrent(run.token)) return;
         status.textContent = "Comparison complete.";
         renderCohortComparison(result);
       })
       .catch(function (error) {
+        clearTimeout(coldStartNotice);
+        if (!profileMatchController.isCurrent(run.token)) return;
         button.disabled = false;
         select.disabled = false;
-        status.textContent = "The comparison backend is unavailable. Please try again.";
+        status.textContent = error.message && error.message.toLowerCase().includes("timed out")
+          ? "The comparison timed out while the backend was waking. Retry when ready."
+          : "The comparison backend is unavailable. Retry when ready.";
         console.error("Profile matching error:", error);
       });
   }
@@ -931,6 +986,7 @@
   }
 
   function startOverDemoProfile() {
+    profileMatchController.cancel();
     profileSession.reset();
     history = history.filter(function (item) { return item.scope !== "profile"; });
     messagesEl.querySelectorAll("[data-profile-scope]").forEach(function (element) {

--- a/chatbot/embedding-demo.js
+++ b/chatbot/embedding-demo.js
@@ -25,12 +25,15 @@
       !preset.preset_id ||
       !preset.target ||
       !["compact", "multi_region", "overview"].includes(preset.display_mode) ||
+      (preset.display_mode === "multi_region" &&
+        (!Number.isInteger(preset.minimum_region_size) ||
+          preset.minimum_region_size < 1)) ||
       !Array.isArray(preset.visual_reference_ids) ||
       !preset.visual_reference_ids.length
     ) {
       throw new Error("Preset response is missing the visualization contract");
     }
-    return {
+    var request = {
       type: "preset_selection",
       dataset_version: preset.dataset_version,
       preset_id: preset.preset_id,
@@ -45,6 +48,10 @@
       created_at: createdAt || new Date().toISOString(),
       consumed: false,
     };
+    if (preset.display_mode === "multi_region") {
+      request.minimum_region_size = preset.minimum_region_size;
+    }
+    return request;
   }
 
   function createMatchedRequest(result, createdAt) {
@@ -56,6 +63,8 @@
       !comparison ||
       comparison.status !== "matched_reference_neighborhood" ||
       !comparison.target ||
+      !Number.isInteger(comparison.minimum_display_region_size) ||
+      comparison.minimum_display_region_size < 1 ||
       !Array.isArray(result.visual_reference_ids) ||
       !result.visual_reference_ids.length ||
       !aggregate ||
@@ -68,6 +77,7 @@
       dataset_version: result.dataset_version,
       target: comparison.target,
       display_mode: "matched_selection",
+      minimum_region_size: comparison.minimum_display_region_size,
       visual_reference_ids: result.visual_reference_ids.slice(),
       summary: {
         reference_count: aggregate.reference_count,
@@ -80,6 +90,66 @@
       created_at: createdAt || new Date().toISOString(),
       consumed: false,
     };
+  }
+
+  function createRequestController() {
+    var generation = 0;
+    var activeController = null;
+    return {
+      start: function () {
+        generation += 1;
+        if (activeController) {
+          activeController.abort(new Error("Superseded by a newer request"));
+        }
+        activeController = new AbortController();
+        return { token: generation, signal: activeController.signal };
+      },
+      cancel: function () {
+        generation += 1;
+        if (activeController) {
+          activeController.abort(new Error("Request cancelled"));
+          activeController = null;
+        }
+      },
+      isCurrent: function (token) {
+        return token === generation;
+      },
+    };
+  }
+
+  function requestJson(fetchImpl, url, options, timeoutMs) {
+    var requestOptions = Object.assign({}, options || {});
+    var externalSignal = requestOptions.signal;
+    var controller = new AbortController();
+    var timedOut = false;
+    var timeout = setTimeout(function () {
+      timedOut = true;
+      controller.abort(new Error("Backend request timed out"));
+    }, timeoutMs || 30000);
+    var cancelFromExternal = function () {
+      controller.abort(externalSignal.reason || new Error("Request cancelled"));
+    };
+    if (externalSignal) {
+      if (externalSignal.aborted) cancelFromExternal();
+      else externalSignal.addEventListener("abort", cancelFromExternal, { once: true });
+    }
+    requestOptions.signal = controller.signal;
+
+    return fetchImpl(url, requestOptions)
+      .then(function (response) {
+        if (!response.ok) throw new Error("Backend returned " + response.status);
+        return response.json();
+      })
+      .catch(function (error) {
+        if (timedOut) throw new Error("Backend request timed out. Retry when ready.");
+        throw error;
+      })
+      .finally(function () {
+        clearTimeout(timeout);
+        if (externalSignal) {
+          externalSignal.removeEventListener("abort", cancelFromExternal);
+        }
+      });
   }
 
   function saveRequest(storage, request) {
@@ -134,8 +204,10 @@
     REQUEST_EVENT: REQUEST_EVENT,
     createPresetRequest: createPresetRequest,
     createMatchedRequest: createMatchedRequest,
+    createRequestController: createRequestController,
     saveRequest: saveRequest,
     notifyRequest: notifyRequest,
+    requestJson: requestJson,
     connectRequestConsumer: connectRequestConsumer,
     consumeRequest: consumeRequest,
     resolveApiUrl: resolveApiUrl,

--- a/chatbot/embedding-demo.test.cjs
+++ b/chatbot/embedding-demo.test.cjs
@@ -54,6 +54,21 @@ test("preset request stores only the visualization contract", () => {
 });
 
 
+test("multi-region preset requires and preserves its release geometry contract", () => {
+  const multiRegion = { ...preset, display_mode: "multi_region" };
+  assert.throws(
+    () => demo.createPresetRequest(multiRegion),
+    /missing the visualization contract/,
+  );
+
+  const request = demo.createPresetRequest({
+    ...multiRegion,
+    minimum_region_size: 5,
+  });
+  assert.equal(request.minimum_region_size, 5);
+});
+
+
 test("request plays once and remains available as a final replayable state", () => {
   const storage = memoryStorage();
   const request = demo.createPresetRequest(preset, "2026-07-13T12:00:00.000Z");
@@ -130,6 +145,7 @@ test("matched result request stores exact references and aggregate context witho
       status: "matched_reference_neighborhood",
       target: "MASH",
       neighborhood_size: 2,
+      minimum_display_region_size: 5,
     },
     visual_reference_ids: ["vr_match_one", "vr_match_two"],
     aggregate_callout_data: {
@@ -157,6 +173,7 @@ test("matched result request stores exact references and aggregate context witho
     "created_at",
     "dataset_version",
     "display_mode",
+    "minimum_region_size",
     "summary",
     "target",
     "type",
@@ -164,8 +181,36 @@ test("matched result request stores exact references and aggregate context witho
   ]);
   assert.equal(request.type, "matched_reference_neighborhood");
   assert.equal(request.display_mode, "matched_selection");
+  assert.equal(request.minimum_region_size, 5);
   assert.deepEqual(request.visual_reference_ids, ["vr_match_one", "vr_match_two"]);
   assert.equal(request.summary.domains[0].metrics[0].median, 55);
   assert.equal(JSON.stringify(request).includes("confirmed_profile"), false);
   assert.equal(JSON.stringify(request).includes("reported_features"), false);
+});
+
+
+test("new backend request cancels the stale request token", () => {
+  const controller = demo.createRequestController();
+  const first = controller.start();
+  const second = controller.start();
+
+  assert.equal(first.signal.aborted, true);
+  assert.equal(controller.isCurrent(first.token), false);
+  assert.equal(controller.isCurrent(second.token), true);
+});
+
+
+test("JSON request exposes timeout as a retryable failure", async () => {
+  const neverCompletes = function (_url, options) {
+    return new Promise(function (_resolve, reject) {
+      options.signal.addEventListener("abort", function () {
+        reject(options.signal.reason);
+      });
+    });
+  };
+
+  await assert.rejects(
+    demo.requestJson(neverCompletes, "https://example.test/data", {}, 1),
+    /timed out/i,
+  );
 });

--- a/docs/demo-profile-edge-state-validation-2026-07-14.md
+++ b/docs/demo-profile-edge-state-validation-2026-07-14.md
@@ -1,0 +1,88 @@
+# Demo Profile Edge-State Validation
+
+**Date:** 2026-07-14
+
+**Scope:** Issue #27 partial Profile Coverage, display layout, accessibility, and
+backend failure behavior
+
+This change note extends the accepted chatbot embedding design and the existing
+matching-calibration evidence. It does not replace those historical documents.
+
+## Partial Profile Coverage
+
+The matching service continues to admit only exact target/domain patterns that
+passed the tracked masking experiments. Missing domains are never imputed and
+do not contribute to distance or aggregate callouts.
+
+When a Confirmed Profile is not eligible, the service now returns the nearest
+complete calibrated pattern rather than inventing a single preferred field. It
+ranks calibrated supersets by:
+
+1. fewest missing domains;
+2. higher 10th-percentile top-five-neighbor overlap;
+3. higher median top-five-neighbor overlap;
+4. stable pattern name for deterministic ties.
+
+The recommendation lists every domain still needed for that calibrated pattern
+and maps each domain to supported, visitor-readable measurements. This avoids
+claiming that one measurement is sufficient when the target's evidence requires
+several domains.
+
+Confirmed values outside the current reference support remain unchanged. The
+response identifies their domains as an edge state; a No Stable Neighborhood
+explains the cohort limitation without claiming that comparable people do not
+exist elsewhere.
+
+## Display Region Method
+
+Display Regions organize the already-selected Visual Reference IDs only. They
+do not participate in Profile Similarity.
+
+For each selected point, the renderer calculates its distance to the fifth
+nearest point in the same target cohort. Two selected points are connected only
+when each falls within the other's local fifth-neighbor radius. Connected
+components must also share a local center: their component center must fall
+within every member's local radius. This rejects single-link chains that span
+the embedding while remaining locally connected. Components are interpreted
+as follows:
+
+- one component containing the whole selection: `compact`;
+- multiple components, each meeting the release suppression minimum:
+  `multi_region`;
+- any ungrouped or privacy-small component: dispersed `overview`.
+
+The fifth-neighbor count is the release-controlled minimum display/aggregate
+group size. The component-center check is scaled separately by every member's
+release-derived local radius; it does not introduce a fixed global t-SNE
+distance or mock clinical threshold. Multi-region navigation reveals only
+display-safe counts and the existing whole-neighborhood aggregate; it does not
+create clinical summaries for individual regions.
+
+## Accessibility and Control
+
+- The canvas is exposed as an image and points to a DOM Neighborhood Summary.
+- Compact, multi-region, and dispersed layouts have distinct text outside the
+  canvas.
+- Multi-region results expose native Back and Next buttons with bounded states
+  and a live region-position announcement. Before entering region 1, a
+  display-only overlay shows every region outline and number from normalized
+  coordinates; the overlay never feeds back into classification or matching.
+- Replay and Reset remain available; a new request or Start Over cancels the
+  previous backend request.
+- Reduced motion skips camera transitions and renders the final highlighted
+  state directly.
+- Visitor interruption or tab hiding cancels motion and restores the neutral
+  overview instead of leaving stale highlights. Renderer writes are serialized,
+  so the neutral reset runs after any in-flight stale draw or camera operation.
+
+## Backend Loading and Retry
+
+Backend reads use an abortable 30-second operational request budget. After four
+seconds the interface explains that the Hugging Face backend may be waking from
+a cold start. Timeout or failure produces an explicit Retry path; a newer load
+invalidates the older token, so a late response cannot replace the current
+view. These timings are user-interface operational parameters, not scientific
+or clinical thresholds.
+
+No local patient-data fallback, row-number mapping, coordinate-nearest mapping,
+or stale Dataset Release is used.

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -391,6 +391,11 @@ figcaption {
   max-width: 100%;
 }
 
+.embedding-frame canvas:focus-visible {
+  outline: 3px solid rgba(44, 90, 160, 0.45);
+  outline-offset: 2px;
+}
+
 .embedding-region {
   position: absolute;
   inset: 0;
@@ -401,6 +406,41 @@ figcaption {
 
 .embedding-region.is-visible {
   opacity: 1;
+}
+
+.embedding-multi-region-overview {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 220ms ease;
+}
+
+.embedding-multi-region-overview.is-visible {
+  opacity: 1;
+}
+
+.embedding-region-outline {
+  position: absolute;
+  border: 3px dashed #ef6c00;
+  border-radius: 999px;
+  background: rgba(255, 167, 38, 0.08);
+}
+
+.embedding-region-outline span {
+  position: absolute;
+  top: -0.75rem;
+  left: -0.75rem;
+  display: grid;
+  width: 1.5rem;
+  height: 1.5rem;
+  place-items: center;
+  border: 2px solid #fff;
+  border-radius: 50%;
+  background: #d84315;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 800;
 }
 
 .embedding-region svg {
@@ -456,6 +496,14 @@ figcaption {
   color: #486581;
   font-size: 0.82rem;
   font-weight: 600;
+}
+
+.embedding-region-status {
+  min-width: 9.5rem;
+  color: #334e68;
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-align: center;
 }
 
 .embedding-button {
@@ -514,6 +562,7 @@ figcaption {
 
 .embedding-summary dl {
   display: flex;
+  flex-wrap: wrap;
   gap: 1.5rem;
   margin: 0.65rem 0 0;
 }
@@ -558,6 +607,13 @@ figcaption {
 .embedding-summary-note {
   color: #6c757d;
   font-style: italic;
+}
+
+.embedding-layout-note {
+  padding: 0.65rem 0.75rem;
+  border-left: 3px solid #d9822b;
+  background: #fff8ed;
+  color: #7c4a03;
 }
 
 .embedding-legend {
@@ -606,6 +662,7 @@ figcaption {
 
 .quarto-dark .embedding-heading span,
 .quarto-dark .embedding-status,
+.quarto-dark .embedding-region-status,
 .quarto-dark .embedding-legend {
   color: #a9bacb;
 }
@@ -644,12 +701,22 @@ figcaption {
   color: #8bb5ec;
 }
 
+.quarto-dark .embedding-layout-note {
+  border-left-color: #f0a35e;
+  background: #392d21;
+  color: #f5d0a9;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .embedding-spinner {
     animation: none;
   }
 
   .embedding-region {
+    transition: none;
+  }
+
+  .embedding-multi-region-overview {
     transition: none;
   }
 }

--- a/viz/embedding-scatter.js
+++ b/viz/embedding-scatter.js
@@ -1,3 +1,6 @@
+let embeddingInstanceCounter = 0;
+
+
 export function normalizePoints(data) {
   const xs = data.map((point) => Number(point.tsne_x));
   const ys = data.map((point) => Number(point.tsne_y));
@@ -24,6 +27,144 @@ export function resolveReferenceIndices(data, visualReferenceIds) {
     throw new Error("Visualization request points are outside the active dataset release");
   }
   return visualReferenceIds.map((id) => indexById.get(id));
+}
+
+
+function squaredDistance(points, left, right) {
+  const x = points[left].x - points[right].x;
+  const y = points[left].y - points[right].y;
+  return x * x + y * y;
+}
+
+
+export function classifyDisplayRegions(data, visualReferenceIds, minimumRegionSize) {
+  const selectedIndices = resolveReferenceIndices(data, visualReferenceIds);
+  if (!Number.isInteger(minimumRegionSize) || minimumRegionSize < 1) {
+    throw new Error("Display-region classification requires a positive release minimum");
+  }
+  if (!selectedIndices.length) {
+    return { mode: "overview", regions: [], selected_indices: selectedIndices };
+  }
+  const target = data[selectedIndices[0]].disease;
+  if (selectedIndices.some((index) => data[index].disease !== target)) {
+    throw new Error("A matched visualization request must stay inside one target cohort");
+  }
+
+  const normalized = normalizePoints(data);
+  const targetIndices = data
+    .map((point, index) => (point.disease === target ? index : null))
+    .filter((index) => index !== null);
+  if (targetIndices.length <= minimumRegionSize) {
+    return { mode: "overview", regions: [], selected_indices: selectedIndices };
+  }
+
+  const localRadius = new Map();
+  selectedIndices.forEach((selectedIndex) => {
+    const distances = targetIndices
+      .filter((index) => index !== selectedIndex)
+      .map((index) => squaredDistance(normalized, selectedIndex, index))
+      .sort((left, right) => left - right);
+    localRadius.set(selectedIndex, distances[minimumRegionSize - 1]);
+  });
+
+  const neighbors = new Map(selectedIndices.map((index) => [index, []]));
+  selectedIndices.forEach((left, leftPosition) => {
+    selectedIndices.slice(leftPosition + 1).forEach((right) => {
+      const threshold = Math.min(localRadius.get(left), localRadius.get(right));
+      if (squaredDistance(normalized, left, right) <= threshold) {
+        neighbors.get(left).push(right);
+        neighbors.get(right).push(left);
+      }
+    });
+  });
+
+  const unseen = new Set(selectedIndices);
+  const components = [];
+  selectedIndices.forEach((start) => {
+    if (!unseen.has(start)) return;
+    const component = [];
+    const queue = [start];
+    unseen.delete(start);
+    while (queue.length) {
+      const current = queue.shift();
+      component.push(current);
+      neighbors.get(current).forEach((neighbor) => {
+        if (!unseen.has(neighbor)) return;
+        unseen.delete(neighbor);
+        queue.push(neighbor);
+      });
+    }
+    components.push(component);
+  });
+
+  const isLocallyCentered = (component) => {
+    const center = component.reduce(
+      (total, index) => ({
+        x: total.x + normalized[index].x / component.length,
+        y: total.y + normalized[index].y / component.length,
+      }),
+      { x: 0, y: 0 },
+    );
+    return component.every((index) => {
+      const x = normalized[index].x - center.x;
+      const y = normalized[index].y - center.y;
+      return x * x + y * y <= localRadius.get(index);
+    });
+  };
+  const safeComponents = components.every((component) =>
+    component.length >= minimumRegionSize && isLocallyCentered(component),
+  );
+
+  if (components.length === 1 && safeComponents) {
+    return { mode: "compact", regions: components, selected_indices: selectedIndices };
+  }
+  if (components.length > 1 && safeComponents) {
+    return { mode: "multi_region", regions: components, selected_indices: selectedIndices };
+  }
+  return { mode: "overview", regions: [], selected_indices: selectedIndices };
+}
+
+
+export function createRegionNavigator(regions) {
+  let index = 0;
+  return {
+    back() {
+      index = Math.max(0, index - 1);
+      return this.state();
+    },
+    next() {
+      index = Math.min(regions.length - 1, index + 1);
+      return this.state();
+    },
+    state() {
+      return {
+        index,
+        count: regions.length,
+        region: regions[index],
+        canBack: index > 0,
+        canNext: index < regions.length - 1,
+      };
+    },
+  };
+}
+
+
+export function regionOutlinePercentages(points, regions) {
+  return regions.map((region, index) => {
+    const xs = region.map((pointIndex) => points[pointIndex].x);
+    const ys = region.map((pointIndex) => points[pointIndex].y);
+    const centerX = ((Math.min(...xs) + Math.max(...xs)) / 2 + 1) * 50;
+    const centerY = (1 - (Math.min(...ys) + Math.max(...ys)) / 2) * 50;
+    const width = Math.max(6, (Math.max(...xs) - Math.min(...xs)) * 50 + 4);
+    const height = Math.max(8, (Math.max(...ys) - Math.min(...ys)) * 50 + 6);
+    return {
+      label: String(index + 1),
+      left: Math.max(0, Math.min(100 - width, centerX - width / 2)),
+      top: Math.max(0, Math.min(100 - height, centerY - height / 2)),
+      width,
+      height,
+    };
+  });
 }
 
 
@@ -69,6 +210,52 @@ export function createRunController() {
       return token === currentToken;
     },
   };
+}
+
+
+export function createRendererQueue() {
+  let tail = Promise.resolve();
+  return {
+    run(operation) {
+      tail = tail.catch(() => {}).then(operation);
+      return tail;
+    },
+  };
+}
+
+
+export function layoutForRequest(data, request, indices) {
+  if (request?.type === "matched_reference_neighborhood") {
+    if (!Number.isInteger(request.minimum_region_size) || request.minimum_region_size < 1) {
+      throw new Error("Matched visualization request is missing its geometry contract");
+    }
+    return classifyDisplayRegions(
+      data,
+      request.visual_reference_ids,
+      request.minimum_region_size,
+    );
+  }
+  if (request?.display_mode === "compact") {
+    return { mode: "compact", regions: [indices], selected_indices: indices };
+  }
+  if (request?.display_mode === "overview") {
+    return { mode: "overview", regions: [], selected_indices: indices };
+  }
+  if (request?.display_mode === "multi_region") {
+    if (!Number.isInteger(request.minimum_region_size) || request.minimum_region_size < 1) {
+      throw new Error("Multi-region preset is missing its geometry contract");
+    }
+    const layout = classifyDisplayRegions(
+      data,
+      request.visual_reference_ids,
+      request.minimum_region_size,
+    );
+    if (layout.mode !== "multi_region") {
+      throw new Error("Multi-region preset does not match its release geometry");
+    }
+    return layout;
+  }
+  throw new Error("Visualization request has an unsupported display mode");
 }
 
 
@@ -119,6 +306,8 @@ export async function createEmbeddingScatter(config) {
   const width = fitWidth(config.width || 1000);
   const height = Math.max(380, Math.round(width * 0.62));
   const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  embeddingInstanceCounter += 1;
+  const instanceId = `fibrotic-walkthrough-${embeddingInstanceCounter}`;
 
   const shell = document.createElement("section");
   shell.className = "embedding-walkthrough";
@@ -139,7 +328,10 @@ export async function createEmbeddingScatter(config) {
   canvas.height = height;
   canvas.style.width = `${width}px`;
   canvas.style.height = `${height}px`;
+  canvas.setAttribute("role", "img");
   canvas.setAttribute("aria-label", `${data.length.toLocaleString()} reference points`);
+  canvas.setAttribute("aria-describedby", `${instanceId}-summary`);
+  canvas.tabIndex = 0;
   frame.appendChild(canvas);
 
   const region = document.createElement("div");
@@ -153,6 +345,11 @@ export async function createEmbeddingScatter(config) {
     "</svg>";
   frame.appendChild(region);
 
+  const multiRegionOverview = document.createElement("div");
+  multiRegionOverview.className = "embedding-multi-region-overview";
+  multiRegionOverview.setAttribute("aria-hidden", "true");
+  frame.appendChild(multiRegionOverview);
+
   const tooltip = document.createElement("div");
   tooltip.className = "embedding-tooltip";
   frame.appendChild(tooltip);
@@ -165,14 +362,35 @@ export async function createEmbeddingScatter(config) {
   status.setAttribute("aria-live", "polite");
   status.textContent = "Overview · waiting for a walkthrough request";
   const playButton = button("Play walkthrough", "embedding-button embedding-button-primary");
+  const backButton = button("Back region");
+  backButton.setAttribute("aria-label", "Show previous display region");
+  const regionStatus = document.createElement("span");
+  regionStatus.className = "embedding-region-status";
+  regionStatus.setAttribute("aria-live", "polite");
+  const nextButton = button("Next region");
+  nextButton.setAttribute("aria-label", "Show next display region");
   const replayButton = button("Replay");
   const resetButton = button("Reset view");
+  backButton.hidden = true;
+  regionStatus.hidden = true;
+  nextButton.hidden = true;
   replayButton.hidden = true;
-  controls.append(status, playButton, replayButton, resetButton);
+  controls.append(
+    status,
+    playButton,
+    backButton,
+    regionStatus,
+    nextButton,
+    replayButton,
+    resetButton,
+  );
   shell.appendChild(controls);
 
   const summary = document.createElement("aside");
   summary.className = "embedding-summary";
+  summary.id = `${instanceId}-summary`;
+  summary.setAttribute("role", "region");
+  summary.setAttribute("aria-label", "Matched reference neighborhood summary");
   summary.tabIndex = -1;
   summary.hidden = true;
   shell.appendChild(summary);
@@ -201,9 +419,14 @@ export async function createEmbeddingScatter(config) {
     y: normalized.map((point) => point.y),
   };
   let activeRequest = config.request || config.preset;
+  let activeLayout = null;
+  let regionNavigator = null;
+  let regionTransitionActive = false;
   const runController = createRunController();
+  const regionController = createRunController();
+  const rendererQueue = createRendererQueue();
 
-  async function drawOverview() {
+  async function renderOverview() {
     scatterplot.set({
       colorBy: "valueA",
       opacityBy: null,
@@ -219,38 +442,122 @@ export async function createEmbeddingScatter(config) {
     scatterplot.deselect({ preventEvent: true });
   }
 
-  async function drawDimmed() {
-    scatterplot.set({
-      colorBy: "valueA",
-      opacityBy: null,
-      sizeBy: null,
-      pointColor: ["#aeb7c2"],
-      opacity: 0.2,
-      pointSize: 2.5,
-    });
-    await scatterplot.draw({ ...columns, z: data.map(() => 0) });
+  function drawOverview() {
+    return rendererQueue.run(renderOverview);
   }
 
-  async function drawHighlighted(indices) {
-    const selected = new Set(indices);
-    scatterplot.set({
-      colorBy: "valueA",
-      opacityBy: "valueA",
-      sizeBy: "valueA",
-      pointColor: ["#aeb7c2", "#1565c0"],
-      opacity: [0.14, 1],
-      pointSize: [2.5, 8],
+  function drawDimmed() {
+    return rendererQueue.run(async () => {
+      scatterplot.set({
+        colorBy: "valueA",
+        opacityBy: null,
+        sizeBy: null,
+        pointColor: ["#aeb7c2"],
+        opacity: 0.2,
+        pointSize: 2.5,
+      });
+      await scatterplot.draw({ ...columns, z: data.map(() => 0) });
     });
-    await scatterplot.draw(
-      { ...columns, z: data.map((_, index) => (selected.has(index) ? 1 : 0)) },
-      { preventFilterReset: true },
-    );
-    scatterplot.select(indices, { preventEvent: true });
   }
 
-  function showCallout(request) {
+  function drawHighlighted(indices) {
+    return rendererQueue.run(async () => {
+      const selected = new Set(indices);
+      scatterplot.set({
+        colorBy: "valueA",
+        opacityBy: "valueA",
+        sizeBy: "valueA",
+        pointColor: ["#aeb7c2", "#1565c0"],
+        opacity: [0.14, 1],
+        pointSize: [2.5, 8],
+      });
+      await scatterplot.draw(
+        { ...columns, z: data.map((_, index) => (selected.has(index) ? 1 : 0)) },
+        { preventFilterReset: true },
+      );
+      scatterplot.select(indices, { preventEvent: true });
+    });
+  }
+
+  function zoomToPoints(indices, options) {
+    return rendererQueue.run(() => scatterplot.zoomToPoints(indices, options));
+  }
+
+  function restoreOverview() {
+    return rendererQueue.run(async () => {
+      await renderOverview();
+      await scatterplot.zoomToPoints(allIndices, { padding: 0.08 });
+    });
+  }
+
+  function hideRegionNavigation() {
+    backButton.hidden = true;
+    regionStatus.hidden = true;
+    nextButton.hidden = true;
+  }
+
+  function hideMultiRegionOverview() {
+    multiRegionOverview.classList.remove("is-visible");
+    multiRegionOverview.replaceChildren();
+  }
+
+  function showMultiRegionOverview(layout) {
+    multiRegionOverview.replaceChildren();
+    regionOutlinePercentages(normalized, layout.regions).forEach((outline) => {
+      const marker = document.createElement("div");
+      marker.className = "embedding-region-outline";
+      marker.style.left = `${outline.left}%`;
+      marker.style.top = `${outline.top}%`;
+      marker.style.width = `${outline.width}%`;
+      marker.style.height = `${outline.height}%`;
+      const label = document.createElement("span");
+      label.textContent = outline.label;
+      marker.appendChild(label);
+      multiRegionOverview.appendChild(marker);
+    });
+    multiRegionOverview.classList.add("is-visible");
+  }
+
+  function updateRegionNavigation() {
+    if (!regionNavigator || activeLayout?.mode !== "multi_region") {
+      hideRegionNavigation();
+      return;
+    }
+    const navigation = regionNavigator.state();
+    backButton.hidden = false;
+    regionStatus.hidden = false;
+    nextButton.hidden = false;
+    backButton.disabled = !navigation.canBack;
+    nextButton.disabled = !navigation.canNext;
+    regionStatus.textContent = `Display region ${navigation.index + 1} of ${navigation.count}`;
+  }
+
+  async function focusCurrentRegion(animate) {
+    const token = regionController.start();
+    regionTransitionActive = true;
+    const navigation = regionNavigator.state();
+    backButton.disabled = true;
+    nextButton.disabled = true;
+    status.textContent =
+      `Display region ${navigation.index + 1} of ${navigation.count} · ` +
+      `${navigation.region.length} highlighted reference points`;
+    region.classList.add("is-visible");
+    try {
+      await zoomToPoints(navigation.region, {
+        padding: 0.25,
+        transition: animate,
+        transitionDuration: animate ? 620 : 0,
+      });
+    } finally {
+      if (regionController.isCurrent(token)) regionTransitionActive = false;
+    }
+    if (!regionController.isCurrent(token)) return;
+    updateRegionNavigation();
+  }
+
+  function showCallout(request, layout) {
     const copy = walkthroughCopy(request);
-    region.classList.toggle("is-visible", request.display_mode === "compact");
+    region.classList.toggle("is-visible", layout.mode !== "overview");
     summary.hidden = false;
     summary.replaceChildren();
     const kicker = document.createElement("div");
@@ -264,6 +571,14 @@ export async function createEmbeddingScatter(config) {
     [
       ["Reference points", request.summary.reference_count],
       ["Target", config.displayName(request.target)],
+      [
+        "Display layout",
+        layout.mode === "compact"
+          ? "One compact display region"
+          : layout.mode === "multi_region"
+            ? `${layout.regions.length} separated display regions`
+            : "Dispersed overview",
+      ],
     ].forEach(([term, value]) => {
       const pair = document.createElement("div");
       const key = document.createElement("dt");
@@ -278,6 +593,15 @@ export async function createEmbeddingScatter(config) {
     note.textContent =
       "Display preset only; no query patient is embedded and no clinical similarity or personal outcome is inferred.";
     summary.append(kicker, title, description, details, note);
+    const layoutNote = document.createElement("p");
+    layoutNote.className = "embedding-layout-note";
+    layoutNote.textContent =
+      layout.mode === "compact"
+        ? "The highlighted references occupy one local display region. This region is an annotation aid, not a clinical cluster."
+        : layout.mode === "multi_region"
+          ? "The highlighted references occupy separated display regions. Use Back and Next to inspect them; the regions are annotation aids, not clinical subtypes."
+          : "The highlighted references are broadly dispersed, so the full embedding overview is preserved instead of drawing a misleading region.";
+    summary.insertBefore(layoutNote, note);
     if (Array.isArray(request.summary.domains)) {
       request.summary.domains.forEach((domain) => {
         const domainSection = document.createElement("section");
@@ -307,14 +631,33 @@ export async function createEmbeddingScatter(config) {
     status.textContent = `Walkthrough complete · ${request.summary.reference_count} reference points highlighted`;
     replayButton.hidden = false;
     playButton.hidden = true;
+    updateRegionNavigation();
   }
 
   async function play(request, animate = !reducedMotion) {
     activeRequest = request;
     const token = runController.start();
-    const indices = resolveReferenceIndices(data, request.visual_reference_ids);
+    regionController.cancel();
+    regionTransitionActive = false;
+    let indices;
+    let layout;
+    try {
+      indices = resolveReferenceIndices(data, request.visual_reference_ids);
+      layout = layoutForRequest(data, request, indices);
+    } catch (error) {
+      cancelRun(
+        "The visualization request does not match the active Dataset Release. Start the comparison again.",
+      );
+      return;
+    }
+    activeLayout = layout;
+    regionNavigator = layout.regions.length
+      ? createRegionNavigator(layout.regions)
+      : null;
     region.classList.remove("is-visible");
     summary.hidden = true;
+    hideRegionNavigation();
+    hideMultiRegionOverview();
     playButton.disabled = true;
     replayButton.disabled = true;
     resetButton.disabled = true;
@@ -323,7 +666,7 @@ export async function createEmbeddingScatter(config) {
       if (stage === "overview") {
         status.textContent = "Overview · preparing reference cohort";
         await drawOverview();
-        await scatterplot.zoomToPoints(allIndices, { padding: 0.08 });
+        await zoomToPoints(allIndices, { padding: 0.08 });
         await delay(380);
       } else if (stage === "dim") {
         status.textContent = "Dimming unrelated reference points";
@@ -334,23 +677,28 @@ export async function createEmbeddingScatter(config) {
         await drawHighlighted(indices);
         if (animate) await delay(420);
       } else if (stage === "zoom") {
-        const focusIndices = walkthroughFocusIndices(
-          request.display_mode,
-          allIndices,
-          indices,
-        );
-        status.textContent = request.display_mode === "overview"
-          ? "Keeping the dispersed selection in the full embedding overview"
-          : request.display_mode === "matched_selection"
-            ? "Fitting the exact matched reference selection"
-            : "Zooming to the display region";
-        await scatterplot.zoomToPoints(focusIndices, {
-          padding: request.display_mode === "overview" ? 0.08 : 0.25,
-          transition: animate,
-          transitionDuration: animate ? 760 : 0,
-        });
+        if (layout.mode === "multi_region") {
+          if (animate) {
+            status.textContent = `Showing ${layout.regions.length} separated display regions`;
+            showMultiRegionOverview(layout);
+            await delay(900);
+            if (!runController.isCurrent(token)) return;
+            hideMultiRegionOverview();
+          }
+          await focusCurrentRegion(animate);
+        } else {
+          const focusIndices = layout.mode === "overview" ? allIndices : indices;
+          status.textContent = layout.mode === "overview"
+            ? "Keeping broadly dispersed matches in the full embedding overview"
+            : "Zooming to the compact display region";
+          await zoomToPoints(focusIndices, {
+            padding: layout.mode === "overview" ? 0.08 : 0.25,
+            transition: animate,
+            transitionDuration: animate ? 760 : 0,
+          });
+        }
       } else if (stage === "callout") {
-        showCallout(request);
+        showCallout(request, layout);
       }
       if (!runController.isCurrent(token)) return;
     }
@@ -362,24 +710,36 @@ export async function createEmbeddingScatter(config) {
 
   async function reset() {
     runController.cancel();
+    regionController.cancel();
     region.classList.remove("is-visible");
     summary.hidden = true;
+    activeLayout = null;
+    regionNavigator = null;
+    regionTransitionActive = false;
+    hideRegionNavigation();
+    hideMultiRegionOverview();
     replayButton.hidden = true;
     playButton.hidden = false;
     playButton.disabled = false;
     replayButton.disabled = false;
     resetButton.disabled = false;
     status.textContent = "Overview · walkthrough ready";
-    await drawOverview();
-    await scatterplot.zoomToPoints(allIndices, { padding: 0.08 });
+    await restoreOverview();
   }
 
   function cancelRun(message) {
     runController.cancel();
+    regionController.cancel();
+    regionTransitionActive = false;
     playButton.disabled = false;
     replayButton.disabled = false;
     resetButton.disabled = false;
     status.textContent = message;
+    region.classList.remove("is-visible");
+    summary.hidden = true;
+    hideRegionNavigation();
+    hideMultiRegionOverview();
+    restoreOverview();
   }
 
   bindWalkthroughControls({
@@ -390,15 +750,34 @@ export async function createEmbeddingScatter(config) {
     play,
     reset,
   });
+  backButton.addEventListener("click", () => {
+    regionNavigator.back();
+    focusCurrentRegion(!reducedMotion);
+  });
+  nextButton.addEventListener("click", () => {
+    regionNavigator.next();
+    focusCurrentRegion(!reducedMotion);
+  });
   canvas.addEventListener("pointerdown", () => {
-    if (playButton.disabled) {
+    if (playButton.disabled || regionTransitionActive) {
       cancelRun("Walkthrough paused by visitor interaction");
     }
   });
+  canvas.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancelRun("Walkthrough cancelled and reset to the overview");
+    }
+  });
   document.addEventListener("visibilitychange", () => {
-    if (document.hidden && playButton.disabled) {
+    if (document.hidden && (playButton.disabled || regionTransitionActive)) {
       cancelRun("Walkthrough paused while this tab is hidden");
     }
+  });
+  window.addEventListener("pagehide", () => {
+    runController.cancel();
+    regionController.cancel();
+    regionTransitionActive = false;
   });
   scatterplot.subscribe("pointover", (index) => {
     const point = data[index];
@@ -413,8 +792,7 @@ export async function createEmbeddingScatter(config) {
     tooltip.style.top = `${event.clientY - rect.top + 12}px`;
   });
 
-  await drawOverview();
-  await scatterplot.zoomToPoints(allIndices, { padding: 0.08 });
+  await restoreOverview();
   if (config.autoplay && config.request) {
     window.setTimeout(() => play(config.request), 80);
   } else if (config.request) {

--- a/viz/embedding-scatter.test.mjs
+++ b/viz/embedding-scatter.test.mjs
@@ -4,8 +4,13 @@ import test from "node:test";
 
 import {
   bindWalkthroughControls,
+  classifyDisplayRegions,
+  createRendererQueue,
+  createRegionNavigator,
   createRunController,
+  layoutForRequest,
   normalizePoints,
+  regionOutlinePercentages,
   resolveReferenceIndices,
   walkthroughCopy,
   walkthroughFocusIndices,
@@ -64,6 +69,139 @@ test("overview presets keep the full embedding while compact presets focus", () 
 });
 
 
+function displayPoint(id, x, y, disease = "MASH") {
+  return {
+    visual_reference_id: id,
+    disease,
+    tsne_x: x,
+    tsne_y: y,
+  };
+}
+
+
+test("matched layout distinguishes compact, multi-region, and dispersed selections", () => {
+  const compactCluster = Array.from({ length: 7 }, (_, index) =>
+    displayPoint(`compact_${index}`, index * 0.01, 0),
+  );
+  const secondCluster = Array.from({ length: 7 }, (_, index) =>
+    displayPoint(`second_${index}`, 10 + index * 0.01, 10),
+  );
+  const dispersedSupport = Array.from({ length: 5 }, (_, cluster) =>
+    Array.from({ length: 6 }, (_, index) =>
+      displayPoint(`support_${cluster}_${index}`, cluster * 20 + index * 0.01, 30),
+    ),
+  ).flat();
+  const dispersedIds = dispersedSupport
+    .filter((_, index) => index % 6 === 0)
+    .map((point) => point.visual_reference_id);
+
+  const compact = classifyDisplayRegions(
+    [...compactCluster, ...secondCluster],
+    compactCluster.slice(0, 5).map((point) => point.visual_reference_id),
+    5,
+  );
+  const multi = classifyDisplayRegions(
+    [...compactCluster, ...secondCluster],
+    [
+      ...compactCluster.slice(0, 5),
+      ...secondCluster.slice(0, 5),
+    ].map((point) => point.visual_reference_id),
+    5,
+  );
+  const dispersed = classifyDisplayRegions(dispersedSupport, dispersedIds, 5);
+
+  assert.equal(compact.mode, "compact");
+  assert.deepEqual(compact.regions.map((region) => region.length), [5]);
+  assert.equal(multi.mode, "multi_region");
+  assert.deepEqual(multi.regions.map((region) => region.length), [5, 5]);
+  assert.equal(dispersed.mode, "overview");
+  assert.deepEqual(dispersed.regions, []);
+});
+
+
+test("a locally connected chain remains a dispersed overview", () => {
+  const chain = [0, 1, 2, 3, 4].map((x) => displayPoint(`chain_${x}`, x, 0));
+  const layout = classifyDisplayRegions(
+    chain,
+    chain.slice(0, 4).map((point) => point.visual_reference_id),
+    2,
+  );
+
+  assert.equal(layout.mode, "overview");
+  assert.deepEqual(layout.regions, []);
+});
+
+
+test("multi-region preset rejects missing or contradictory geometry", () => {
+  const first = Array.from({ length: 7 }, (_, index) =>
+    displayPoint(`first_${index}`, index * 0.01, 0),
+  );
+  const second = Array.from({ length: 7 }, (_, index) =>
+    displayPoint(`second_${index}`, 10 + index * 0.01, 10),
+  );
+  const data = [...first, ...second];
+  const visualReferenceIds = [
+    ...first.slice(0, 5),
+    ...second.slice(0, 5),
+  ].map((point) => point.visual_reference_id);
+  const indices = resolveReferenceIndices(data, visualReferenceIds);
+
+  assert.throws(
+    () => layoutForRequest(data, {
+      type: "preset_selection",
+      display_mode: "multi_region",
+      visual_reference_ids: visualReferenceIds,
+    }, indices),
+    /missing its geometry contract/,
+  );
+  assert.equal(layoutForRequest(data, {
+    type: "preset_selection",
+    display_mode: "multi_region",
+    minimum_region_size: 5,
+    visual_reference_ids: visualReferenceIds,
+  }, indices).mode, "multi_region");
+});
+
+
+test("region navigator exposes bounded Back and Next states", () => {
+  const navigator = createRegionNavigator([[1, 2, 3, 4, 5], [8, 9, 10, 11, 12]]);
+
+  assert.deepEqual(navigator.state(), {
+    index: 0,
+    count: 2,
+    region: [1, 2, 3, 4, 5],
+    canBack: false,
+    canNext: true,
+  });
+  navigator.next();
+  assert.equal(navigator.state().index, 1);
+  assert.equal(navigator.state().canNext, false);
+  navigator.next();
+  assert.equal(navigator.state().index, 1);
+  navigator.back();
+  assert.equal(navigator.state().index, 0);
+});
+
+
+test("multi-region overview exposes one numbered outline per display region", () => {
+  const outlines = regionOutlinePercentages(
+    [
+      { x: -0.8, y: 0.7 },
+      { x: -0.7, y: 0.6 },
+      { x: 0.6, y: -0.5 },
+      { x: 0.8, y: -0.7 },
+    ],
+    [[0, 1], [2, 3]],
+  );
+
+  assert.deepEqual(outlines.map((outline) => outline.label), ["1", "2"]);
+  assert.equal(outlines.every((outline) =>
+    outline.left >= 0 && outline.top >= 0 &&
+    outline.left + outline.width <= 100 &&
+    outline.top + outline.height <= 100), true);
+});
+
+
 test("run controller deterministically cancels an active animation", () => {
   const controller = createRunController();
   const first = controller.start();
@@ -74,6 +212,32 @@ test("run controller deterministically cancels an active animation", () => {
   assert.equal(controller.isCurrent(first), false);
   const second = controller.start();
   assert.equal(controller.isCurrent(second), true);
+});
+
+
+test("renderer queue applies the neutral reset after an in-flight stale write", async () => {
+  const queue = createRendererQueue();
+  const writes = [];
+  let releaseStale;
+  let markStarted;
+  const started = new Promise((resolve) => {
+    markStarted = resolve;
+  });
+  const stale = queue.run(() => new Promise((resolve) => {
+    releaseStale = () => {
+      writes.push("stale highlight");
+      resolve();
+    };
+    markStarted();
+  }));
+  const neutral = queue.run(() => {
+    writes.push("neutral overview");
+  });
+
+  await started;
+  releaseStale();
+  await Promise.all([stale, neutral]);
+  assert.deepEqual(writes, ["stale highlight", "neutral overview"]);
 });
 
 
@@ -134,6 +298,7 @@ test("live match crosses session request boundary and focuses exact graph refere
     cohort_comparison_result: {
       status: "matched_reference_neighborhood",
       target: "MASH",
+      minimum_display_region_size: 5,
     },
     visual_reference_ids: ["vr_match_two", "vr_match_one"],
     aggregate_callout_data: {

--- a/viz/use-case.qmd
+++ b/viz/use-case.qmd
@@ -37,7 +37,13 @@ fibroticWalkthrough = {
   const host = document.createElement("div");
   host.className = "embedding-loader";
   host.setAttribute("aria-live", "polite");
+  host.setAttribute("aria-atomic", "true");
   let removeRequestListener = () => {};
+  let loadController = null;
+  invalidation.then(() => {
+    removeRequestListener();
+    if (loadController) loadController.cancel();
+  });
   const colors = [
     "#4477aa", "#ee7733", "#228833", "#cc3311",
     "#aa3377", "#66ccee", "#bbbb44"
@@ -57,6 +63,7 @@ fibroticWalkthrough = {
   const displayName = value => names[value] || String(value).replace(/_/g, " ");
 
   function loading() {
+    host.setAttribute("aria-busy", "true");
     host.innerHTML =
       '<div class="embedding-load-state"><div class="embedding-spinner" aria-hidden="true"></div>' +
       '<strong>Loading the current fibrotic Dataset Release…</strong>' +
@@ -64,9 +71,12 @@ fibroticWalkthrough = {
   }
 
   function failure(message) {
+    host.setAttribute("aria-busy", "false");
     host.innerHTML = "";
     const state = document.createElement("div");
     state.className = "embedding-load-state embedding-load-error";
+    state.setAttribute("role", "alert");
+    state.tabIndex = -1;
     const title = document.createElement("strong");
     title.textContent = "The fibrotic embedding is temporarily unavailable.";
     const detail = document.createElement("span");
@@ -78,6 +88,7 @@ fibroticWalkthrough = {
     retry.addEventListener("click", load);
     state.append(title, detail, retry);
     host.appendChild(state);
+    state.focus({ preventScroll: true });
   }
 
   async function requestHelper() {
@@ -90,19 +101,37 @@ fibroticWalkthrough = {
 
   async function load() {
     loading();
+    let run = null;
+    let coldStartNotice = null;
     try {
       const helper = await requestHelper();
       if (!helper) throw new Error("The visualization request helper is unavailable.");
+      if (!loadController) loadController = helper.createRequestController();
+      run = loadController.start();
+      coldStartNotice = window.setTimeout(() => {
+        if (!loadController.isCurrent(run.token)) return;
+        const detail = host.querySelector(".embedding-load-state span");
+        if (detail) {
+          detail.textContent = "The backend is still waking from a cold start. This attempt will time out safely and offer Retry.";
+        }
+      }, 4000);
       const apiUrl = helper.resolveApiUrl(window.location, window.ALIGATEHR_API_URL);
-      const [embeddingResponse, presetResponse] = await Promise.all([
-        fetch(apiUrl + "/embedding/fibrotic", { cache: "no-store" }),
-        fetch(apiUrl + "/embedding/fibrotic/preset", { cache: "no-store" }),
+      const [embedding, preset] = await Promise.all([
+        helper.requestJson(
+          fetch,
+          apiUrl + "/embedding/fibrotic",
+          { cache: "no-store", signal: run.signal },
+          30000,
+        ),
+        helper.requestJson(
+          fetch,
+          apiUrl + "/embedding/fibrotic/preset",
+          { cache: "no-store", signal: run.signal },
+          30000,
+        ),
       ]);
-      if (!embeddingResponse.ok || !presetResponse.ok) {
-        throw new Error("Backend returned an unavailable response. No local patient-data fallback was used.");
-      }
-      const embedding = await embeddingResponse.json();
-      const preset = await presetResponse.json();
+      window.clearTimeout(coldStartNotice);
+      if (!loadController.isCurrent(run.token)) return;
       if (embedding.dataset_version !== preset.dataset_version) {
         throw new Error("Dataset versions differ. Refresh after the backend release finishes updating.");
       }
@@ -123,6 +152,7 @@ fibroticWalkthrough = {
         autoplay: consumed.should_play,
       });
       host.replaceChildren(chart);
+      host.setAttribute("aria-busy", "false");
       removeRequestListener();
       removeRequestListener = helper.connectRequestConsumer(
         window,
@@ -130,9 +160,10 @@ fibroticWalkthrough = {
         embedding.dataset_version,
         request => chart.embeddingWalkthrough.play(request),
       );
-      invalidation.then(() => removeRequestListener());
       window.__ALIGATEHR_FIBROTIC_READY__ = true;
     } catch (error) {
+      if (coldStartNotice) window.clearTimeout(coldStartNotice);
+      if (run && loadController && !loadController.isCurrent(run.token)) return;
       console.error("Fibrotic embedding load error:", error);
       failure(error.message || "Please retry when the backend is available.");
     }


### PR DESCRIPTION
## Summary

- add calibrated partial Profile Coverage, complete measurement recommendations, and explicit unsupported/out-of-reference-support behavior without treating missing fields as matches
- distinguish compact, numbered multi-region, dispersed, insufficient, and no-result states while preserving aggregate privacy suppression
- add accessible summaries and controls, reduced-motion behavior, serialized cancellation, cold-start/timeout messaging, and retry without stale highlights
- document the evidence-driven display method in a dated validation note

## Impact

Visitors can use partial demo profiles and understand exactly which domains were available, missing, or outside cohort support. Matched references remain display-only cohort context; no unsupported result, individual reference profile, or personal risk inference is introduced.

## Validation

- `python -m pytest -q` — 110 passed
- `node --test chatbot/profile-session.test.cjs chatbot/embedding-demo.test.cjs` — 14 passed
- `node --test viz/embedding-scatter.test.mjs` — 14 passed
- `python scripts/check_ojs_assets.py`
- `quarto render`
- real browser smoke: partial coverage, full match, privacy suppression, dispersed layout, keyboard reset, failure and retry
- Standards and Spec reviews: no remaining P0–P2 findings

Closes #27
