### PR TITLE
Add ICD Keyword Match walkthroughs

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -4,6 +4,7 @@ project:
   resources:
     - chatbot/chatbot.css
     - chatbot/embedding-demo.js
+    - chatbot/icd-keyword.js
     - chatbot/profile-session.js
     - chatbot/chatbot.js
   preview:

--- a/chatbot-backend/app.py
+++ b/chatbot-backend/app.py
@@ -22,6 +22,7 @@ from demo_profile import (
     parse_feature_candidates,
 )
 from profile_matching import load_matching_release, match_confirmed_profile
+from icd_keyword import is_icd_keyword_request, match_icd_keywords
 
 INTENT_SYSTEM_PROMPT = (
     "You are an intent classifier. Given a user message, classify it into exactly one "
@@ -371,6 +372,59 @@ async def assess(req: AssessRequest):
 
 @app.post("/chat", response_model=ChatResponse)
 async def chat(req: ChatRequest):
+    mapping = match_icd_keywords(req.message)
+    if is_icd_keyword_request(
+        req.message,
+        has_reviewed_keyword=mapping["status"] in {"supported", "ambiguous"},
+    ):
+        if mapping["status"] == "supported":
+            count = len(mapping["matches"])
+            return ChatResponse(
+                reply=(
+                    f"I found {count} reviewed ICD Keyword "
+                    f"{'Match' if count == 1 else 'Matches'}. "
+                    "Each action opens one code selection independently; these are "
+                    "navigation aids, not patient history or clinical similarity."
+                ),
+                intent="icd_keyword_match",
+                ui={
+                    "type": "icd_keyword_matches",
+                    "vocabulary_version": mapping["vocabulary_version"],
+                    "matches": mapping["matches"],
+                },
+            )
+        if mapping["status"] == "ambiguous":
+            labels = sorted(
+                {
+                    option["display_label"]
+                    for ambiguity in mapping["ambiguities"]
+                    for option in ambiguity["options"]
+                }
+            )
+            return ChatResponse(
+                reply=(
+                    "That keyword is ambiguous in the reviewed vocabulary. Please "
+                    f"specify one of: {', '.join(labels)}."
+                ),
+                intent="icd_keyword_match",
+                ui={
+                    "type": "icd_keyword_ambiguous",
+                    "vocabulary_version": mapping["vocabulary_version"],
+                    "ambiguities": mapping["ambiguities"],
+                },
+            )
+        return ChatResponse(
+            reply=(
+                "That keyword is not in the reviewed ICD Keyword Vocabulary, so I "
+                "will not guess a code or range."
+            ),
+            intent="icd_keyword_match",
+            ui={
+                "type": "icd_keyword_unsupported",
+                "vocabulary_version": mapping["vocabulary_version"],
+            },
+        )
+
     if client is None:
         raise HTTPException(status_code=503, detail="LLM API key not configured")
 

--- a/chatbot-backend/data/icd_keyword_vocabulary.json
+++ b/chatbot-backend/data/icd_keyword_vocabulary.json
@@ -1,0 +1,81 @@
+{
+  "version": "2026-07-13.v1",
+  "review_status": "researcher-reviewed",
+  "icd_version": "ICD-10 2019",
+  "source": {
+    "name": "WHO ICD-10 2019 Browser",
+    "url": "https://icd.who.int/browse10/2019/en"
+  },
+  "entries": [
+    {
+      "id": "tuberculosis",
+      "canonical_keyword": "tuberculosis",
+      "aliases": ["tb"],
+      "display_label": "Tuberculosis",
+      "selector": {"type": "range", "start": "A15", "end": "A19"},
+      "selector_label": "A15-A19",
+      "source": "WHO ICD-10 2019 Browser",
+      "icd_version": "ICD-10 2019"
+    },
+    {
+      "id": "diabetes-mellitus",
+      "canonical_keyword": "diabetes mellitus",
+      "aliases": ["diabetes"],
+      "display_label": "Diabetes mellitus",
+      "selector": {"type": "range", "start": "E10", "end": "E14"},
+      "selector_label": "E10-E14",
+      "source": "WHO ICD-10 2019 Browser",
+      "icd_version": "ICD-10 2019"
+    },
+    {
+      "id": "type-2-diabetes",
+      "canonical_keyword": "type 2 diabetes",
+      "aliases": ["type ii diabetes", "t2d"],
+      "display_label": "Type 2 diabetes mellitus",
+      "selector": {"type": "exact", "code": "E11"},
+      "selector_label": "E11",
+      "source": "WHO ICD-10 2019 Browser",
+      "icd_version": "ICD-10 2019"
+    },
+    {
+      "id": "essential-hypertension",
+      "canonical_keyword": "essential hypertension",
+      "aliases": ["hypertension", "high blood pressure"],
+      "display_label": "Essential (primary) hypertension",
+      "selector": {"type": "exact", "code": "I10"},
+      "selector_label": "I10",
+      "source": "WHO ICD-10 2019 Browser",
+      "icd_version": "ICD-10 2019"
+    },
+    {
+      "id": "pulmonary-fibrosis",
+      "canonical_keyword": "pulmonary fibrosis",
+      "aliases": ["lung fibrosis"],
+      "display_label": "Other interstitial pulmonary diseases",
+      "selector": {"type": "prefix", "prefix": "J84"},
+      "selector_label": "J84*",
+      "source": "WHO ICD-10 2019 Browser",
+      "icd_version": "ICD-10 2019"
+    },
+    {
+      "id": "chronic-kidney-disease",
+      "canonical_keyword": "chronic kidney disease",
+      "aliases": ["ckd", "chronic renal disease"],
+      "display_label": "Chronic kidney disease",
+      "selector": {"type": "prefix", "prefix": "N18"},
+      "selector_label": "N18*",
+      "source": "WHO ICD-10 2019 Browser",
+      "icd_version": "ICD-10 2019"
+    },
+    {
+      "id": "crohn-disease",
+      "canonical_keyword": "crohn disease",
+      "aliases": ["crohn's disease", "crohns disease"],
+      "display_label": "Crohn disease",
+      "selector": {"type": "prefix", "prefix": "K50"},
+      "selector_label": "K50*",
+      "source": "WHO ICD-10 2019 Browser",
+      "icd_version": "ICD-10 2019"
+    }
+  ]
+}

--- a/chatbot-backend/icd_keyword.py
+++ b/chatbot-backend/icd_keyword.py
@@ -32,11 +32,20 @@ def load_icd_vocabulary(path=VOCABULARY_PATH):
         return json.load(handle)
 
 
+def reviewed_ambiguities(vocabulary):
+    return {
+        normalize_keyword(item.get("term")): set(item.get("entry_ids", []))
+        for item in vocabulary.get("ambiguities", [])
+        if normalize_keyword(item.get("term"))
+    }
+
+
 def validate_vocabulary(vocabulary, codes):
     errors = []
     seen_ids = set()
     seen_terms = {}
     normalized_codes = [normalize_code(code) for code in codes]
+    ambiguity_registry = reviewed_ambiguities(vocabulary)
 
     for entry in vocabulary.get("entries", []):
         entry_id = entry.get("id")
@@ -61,12 +70,28 @@ def validate_vocabulary(vocabulary, codes):
             if not normalized_term:
                 errors.append(f"{entry_id}: keyword or alias is empty")
                 continue
-            owner = seen_terms.get(normalized_term)
-            if owner and owner != entry_id:
-                errors.append(
-                    f"{entry_id}: keyword {normalized_term!r} is also assigned to {owner}"
-                )
-            seen_terms[normalized_term] = entry_id
+            owners = seen_terms.setdefault(normalized_term, set())
+            owners.add(entry_id)
+
+    for normalized_term, owners in seen_terms.items():
+        if len(owners) < 2:
+            continue
+        if ambiguity_registry.get(normalized_term) != owners:
+            owner_list = ", ".join(sorted(owners))
+            errors.append(
+                f"keyword {normalized_term!r} is also assigned to {owner_list} "
+                "without a matching reviewed ambiguity"
+            )
+
+    for normalized_term, entry_ids in ambiguity_registry.items():
+        if len(entry_ids) < 2:
+            errors.append(
+                f"Reviewed ambiguity {normalized_term!r} must name at least two entries"
+            )
+        elif seen_terms.get(normalized_term) != entry_ids:
+            errors.append(
+                f"Reviewed ambiguity {normalized_term!r} does not match its vocabulary entries"
+            )
 
     return errors
 
@@ -88,6 +113,7 @@ def _public_match(entry, matched_keyword):
 
 def match_icd_keywords(message, vocabulary=None):
     vocabulary = vocabulary or load_icd_vocabulary()
+    ambiguity_registry = reviewed_ambiguities(vocabulary)
     normalized_message = normalize_keyword(message)
     candidates = []
 
@@ -120,6 +146,10 @@ def match_icd_keywords(message, vocabulary=None):
     for (start, _, term), entries in sorted(grouped.items()):
         if len(entries) < 2:
             continue
+        if ambiguity_registry.get(term) != set(entries):
+            raise ValueError(
+                f"ICD keyword {term!r} is ambiguous without a reviewed declaration"
+            )
         ambiguities.append(
             {
                 "matched_keyword": term,

--- a/chatbot-backend/icd_keyword.py
+++ b/chatbot-backend/icd_keyword.py
@@ -1,0 +1,175 @@
+import json
+import re
+from pathlib import Path
+
+
+VOCABULARY_PATH = Path(__file__).with_name("data") / "icd_keyword_vocabulary.json"
+SELECTOR_TYPES = {"exact", "prefix", "range"}
+
+
+def normalize_code(value):
+    return re.sub(r"[^A-Z0-9]", "", str(value).upper())
+
+
+def selector_matches_code(selector, code):
+    normalized = normalize_code(code)
+    selector_type = selector.get("type")
+    if selector_type == "exact":
+        return normalized == normalize_code(selector.get("code", ""))
+    if selector_type == "prefix":
+        prefix = normalize_code(selector.get("prefix", ""))
+        return bool(prefix) and normalized.startswith(prefix)
+    if selector_type == "range":
+        category = normalized[:3]
+        start = normalize_code(selector.get("start", ""))[:3]
+        end = normalize_code(selector.get("end", ""))[:3]
+        return len(category) == 3 and len(start) == 3 and len(end) == 3 and start <= category <= end
+    return False
+
+
+def load_icd_vocabulary(path=VOCABULARY_PATH):
+    with Path(path).open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def validate_vocabulary(vocabulary, codes):
+    errors = []
+    seen_ids = set()
+    seen_terms = {}
+    normalized_codes = [normalize_code(code) for code in codes]
+
+    for entry in vocabulary.get("entries", []):
+        entry_id = entry.get("id")
+        if not entry_id or entry_id in seen_ids:
+            errors.append(f"Vocabulary entry has a missing or duplicate id: {entry_id!r}")
+        seen_ids.add(entry_id)
+
+        if entry.get("icd_version") != vocabulary.get("icd_version"):
+            errors.append(f"{entry_id}: ICD version does not match vocabulary metadata")
+        if not entry.get("source"):
+            errors.append(f"{entry_id}: source is required")
+
+        selector = entry.get("selector", {})
+        if selector.get("type") not in SELECTOR_TYPES:
+            errors.append(f"{entry_id}: selector type is unsupported")
+        elif not any(selector_matches_code(selector, code) for code in normalized_codes):
+            errors.append(f"{entry_id}: selector matches no tracked ICD embedding codes")
+
+        terms = [entry.get("canonical_keyword"), *entry.get("aliases", [])]
+        for term in terms:
+            normalized_term = normalize_keyword(term)
+            if not normalized_term:
+                errors.append(f"{entry_id}: keyword or alias is empty")
+                continue
+            owner = seen_terms.get(normalized_term)
+            if owner and owner != entry_id:
+                errors.append(
+                    f"{entry_id}: keyword {normalized_term!r} is also assigned to {owner}"
+                )
+            seen_terms[normalized_term] = entry_id
+
+    return errors
+
+
+def normalize_keyword(value):
+    return " ".join(re.findall(r"[a-z0-9]+", str(value).lower()))
+
+
+def _public_match(entry, matched_keyword):
+    return {
+        "id": entry["id"],
+        "canonical_keyword": entry["canonical_keyword"],
+        "matched_keyword": matched_keyword,
+        "display_label": entry["display_label"],
+        "selector": dict(entry["selector"]),
+        "selector_label": entry["selector_label"],
+    }
+
+
+def match_icd_keywords(message, vocabulary=None):
+    vocabulary = vocabulary or load_icd_vocabulary()
+    normalized_message = normalize_keyword(message)
+    candidates = []
+
+    for entry in vocabulary.get("entries", []):
+        terms = [entry.get("canonical_keyword"), *entry.get("aliases", [])]
+        seen_terms = set()
+        for term in terms:
+            normalized_term = normalize_keyword(term)
+            if not normalized_term or normalized_term in seen_terms:
+                continue
+            seen_terms.add(normalized_term)
+            pattern = rf"(?<![a-z0-9]){re.escape(normalized_term)}(?![a-z0-9])"
+            for occurrence in re.finditer(pattern, normalized_message):
+                candidates.append(
+                    {
+                        "start": occurrence.start(),
+                        "end": occurrence.end(),
+                        "term": normalized_term,
+                        "entry": entry,
+                    }
+                )
+
+    grouped = {}
+    for candidate in candidates:
+        key = (candidate["start"], candidate["end"], candidate["term"])
+        entries = grouped.setdefault(key, {})
+        entries[candidate["entry"]["id"]] = candidate["entry"]
+
+    ambiguities = []
+    for (start, _, term), entries in sorted(grouped.items()):
+        if len(entries) < 2:
+            continue
+        ambiguities.append(
+            {
+                "matched_keyword": term,
+                "position": start,
+                "options": [
+                    _public_match(entry, term)
+                    for entry in sorted(entries.values(), key=lambda item: item["id"])
+                ],
+            }
+        )
+
+    base = {
+        "vocabulary_version": vocabulary.get("version"),
+        "matches": [],
+        "ambiguities": ambiguities,
+    }
+    if ambiguities:
+        return {"status": "ambiguous", **base}
+
+    selected = []
+    selected_ids = set()
+    for candidate in sorted(
+        candidates,
+        key=lambda item: (item["start"], -(item["end"] - item["start"]), item["entry"]["id"]),
+    ):
+        if candidate["entry"]["id"] in selected_ids:
+            continue
+        if any(
+            candidate["start"] < existing["end"]
+            and existing["start"] < candidate["end"]
+            for existing in selected
+        ):
+            continue
+        selected.append(candidate)
+        selected_ids.add(candidate["entry"]["id"])
+
+    if not selected:
+        return {"status": "unsupported", **base}
+
+    base["matches"] = [
+        _public_match(candidate["entry"], candidate["term"])
+        for candidate in selected
+    ]
+    return {"status": "supported", **base}
+
+
+def is_icd_keyword_request(message, has_reviewed_keyword=False):
+    normalized = normalize_keyword(message)
+    has_graph_context = re.search(r"\b(icd|codes?|graph|embedding|umap)\b", normalized)
+    if re.search(r"\b(highlight|jump|locate)\b", normalized):
+        return bool(has_reviewed_keyword or has_graph_context)
+    has_action = re.search(r"\b(show|view|open|find)\b", normalized)
+    return bool(has_action and (has_reviewed_keyword or has_graph_context))

--- a/chatbot-backend/test_app.py
+++ b/chatbot-backend/test_app.py
@@ -189,6 +189,102 @@ def test_classify_intent_garbage_defaults():
         assert result == "paper_qa"
 
 
+# --- ICD keyword walkthrough ---
+
+@pytest.mark.asyncio
+async def test_chat_returns_separate_deterministic_icd_actions_without_llm(client):
+    with patch("app.client") as mock_client:
+        resp = await client.post(
+            "/chat",
+            json={"message": "Show tuberculosis and CKD on the ICD graph"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["intent"] == "icd_keyword_match"
+    assert body["ui"]["type"] == "icd_keyword_matches"
+    assert [match["id"] for match in body["ui"]["matches"]] == [
+        "tuberculosis",
+        "chronic-kidney-disease",
+    ]
+    assert set(body["ui"]["matches"][0]) == {
+        "id",
+        "canonical_keyword",
+        "matched_keyword",
+        "display_label",
+        "selector",
+        "selector_label",
+    }
+    assert "not patient history or clinical similarity" in body["reply"]
+    mock_client.chat.completions.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_explicit_unsupported_icd_request_is_not_guessed(client):
+    with patch("app.client") as mock_client:
+        resp = await client.post(
+            "/chat", json={"message": "Highlight eczema on the ICD graph"}
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["intent"] == "icd_keyword_match"
+    assert body["ui"] == {
+        "type": "icd_keyword_unsupported",
+        "vocabulary_version": "2026-07-13.v1",
+    }
+    assert "not in the reviewed ICD Keyword Vocabulary" in body["reply"]
+    mock_client.chat.completions.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_plain_disease_question_keeps_existing_intent_routing(client):
+    with patch("app.client") as mock_client:
+        mock_client.chat.completions.create.side_effect = [
+            _mock_response("paper_qa"),
+            _mock_response("Paper answer."),
+        ]
+        resp = await client.post(
+            "/chat", json={"message": "What does the paper say about CKD?"}
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["intent"] == "paper_qa"
+    assert mock_client.chat.completions.create.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_unrelated_highlight_request_keeps_existing_intent_routing(client):
+    with patch("app.client") as mock_client:
+        mock_client.chat.completions.create.side_effect = [
+            _mock_response("paper_qa"),
+            _mock_response("Paper answer."),
+        ]
+        resp = await client.post(
+            "/chat", json={"message": "Highlight the paper's main contribution"}
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["intent"] == "paper_qa"
+    assert mock_client.chat.completions.create.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_basic_reviewed_keyword_action_does_not_require_graph_jargon(client):
+    with patch("app.client") as mock_client:
+        resp = await client.post(
+            "/chat", json={"message": "Find type 2 diabetes"}
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["intent"] == "icd_keyword_match"
+    assert [match["id"] for match in body["ui"]["matches"]] == [
+        "type-2-diabetes"
+    ]
+    mock_client.chat.completions.create.assert_not_called()
+
+
 # --- Data query module ---
 
 def test_match_disease_exact():

--- a/chatbot-backend/test_icd_keyword.py
+++ b/chatbot-backend/test_icd_keyword.py
@@ -1,6 +1,8 @@
 import csv
 from pathlib import Path
 
+import pytest
+
 from icd_keyword import load_icd_vocabulary, match_icd_keywords, validate_vocabulary
 
 
@@ -55,26 +57,35 @@ def test_more_specific_reviewed_phrase_wins_without_guessing():
 def test_ambiguous_and_unsupported_input_never_produce_actions():
     ambiguous_vocabulary = {
         "version": "test",
+        "icd_version": "ICD-10 2019",
+        "ambiguities": [
+            {"term": "shared term", "entry_ids": ["left", "right"]},
+        ],
         "entries": [
             {
                 "id": "left",
                 "canonical_keyword": "shared term",
                 "aliases": [],
                 "display_label": "Left",
-                "selector": {"type": "exact", "code": "A15"},
-                "selector_label": "A15",
+                "selector": {"type": "exact", "code": "A00"},
+                "selector_label": "A00",
+                "source": "reviewed test fixture",
+                "icd_version": "ICD-10 2019",
             },
             {
                 "id": "right",
                 "canonical_keyword": "shared term",
                 "aliases": [],
                 "display_label": "Right",
-                "selector": {"type": "exact", "code": "A16"},
-                "selector_label": "A16",
+                "selector": {"type": "exact", "code": "A01"},
+                "selector_label": "A01",
+                "source": "reviewed test fixture",
+                "icd_version": "ICD-10 2019",
             },
         ],
     }
 
+    assert validate_vocabulary(ambiguous_vocabulary, embedding_codes()) == []
     ambiguous = match_icd_keywords("shared term", ambiguous_vocabulary)
     unsupported = match_icd_keywords("eczema")
 
@@ -90,3 +101,17 @@ def test_ambiguous_and_unsupported_input_never_produce_actions():
         "matches": [],
         "ambiguities": [],
     }
+
+
+def test_unreviewed_duplicate_terms_remain_vocabulary_errors():
+    vocabulary = load_icd_vocabulary()
+    duplicate = dict(vocabulary["entries"][0])
+    duplicate["id"] = "unreviewed-duplicate"
+    vocabulary = {**vocabulary, "entries": [*vocabulary["entries"], duplicate]}
+
+    assert any(
+        "is also assigned" in error
+        for error in validate_vocabulary(vocabulary, embedding_codes())
+    )
+    with pytest.raises(ValueError, match="ambiguous without a reviewed declaration"):
+        match_icd_keywords(vocabulary["entries"][0]["canonical_keyword"], vocabulary)

--- a/chatbot-backend/test_icd_keyword.py
+++ b/chatbot-backend/test_icd_keyword.py
@@ -1,0 +1,92 @@
+import csv
+from pathlib import Path
+
+from icd_keyword import load_icd_vocabulary, match_icd_keywords, validate_vocabulary
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def embedding_codes():
+    path = ROOT / "viz" / "data" / "icd_code_embeddings.csv"
+    with path.open(newline="", encoding="utf-8") as handle:
+        return [row["code"] for row in csv.DictReader(handle)]
+
+
+def test_reviewed_vocabulary_selectors_exist_in_the_tracked_icd_embedding():
+    vocabulary = load_icd_vocabulary()
+
+    assert vocabulary["version"] == "2026-07-13.v1"
+    assert vocabulary["icd_version"] == "ICD-10 2019"
+    assert vocabulary["source"]["url"].startswith("https://icd.who.int/")
+    assert {entry["selector"]["type"] for entry in vocabulary["entries"]} == {
+        "exact",
+        "prefix",
+        "range",
+    }
+    assert validate_vocabulary(vocabulary, embedding_codes()) == []
+
+
+def test_deterministic_mapping_keeps_multiple_icd_matches_separate():
+    result = match_icd_keywords("Show tuberculosis and CKD on the ICD graph")
+
+    assert result["status"] == "supported"
+    assert result["vocabulary_version"] == "2026-07-13.v1"
+    assert [match["id"] for match in result["matches"]] == [
+        "tuberculosis",
+        "chronic-kidney-disease",
+    ]
+    assert result["matches"][0]["selector"] == {
+        "type": "range",
+        "start": "A15",
+        "end": "A19",
+    }
+    assert "profile" not in str(result).lower()
+    assert "patient" not in str(result).lower()
+
+
+def test_more_specific_reviewed_phrase_wins_without_guessing():
+    result = match_icd_keywords("Find type 2 diabetes")
+
+    assert result["status"] == "supported"
+    assert [match["id"] for match in result["matches"]] == ["type-2-diabetes"]
+
+
+def test_ambiguous_and_unsupported_input_never_produce_actions():
+    ambiguous_vocabulary = {
+        "version": "test",
+        "entries": [
+            {
+                "id": "left",
+                "canonical_keyword": "shared term",
+                "aliases": [],
+                "display_label": "Left",
+                "selector": {"type": "exact", "code": "A15"},
+                "selector_label": "A15",
+            },
+            {
+                "id": "right",
+                "canonical_keyword": "shared term",
+                "aliases": [],
+                "display_label": "Right",
+                "selector": {"type": "exact", "code": "A16"},
+                "selector_label": "A16",
+            },
+        ],
+    }
+
+    ambiguous = match_icd_keywords("shared term", ambiguous_vocabulary)
+    unsupported = match_icd_keywords("eczema")
+
+    assert ambiguous["status"] == "ambiguous"
+    assert ambiguous["matches"] == []
+    assert [option["id"] for option in ambiguous["ambiguities"][0]["options"]] == [
+        "left",
+        "right",
+    ]
+    assert unsupported == {
+        "status": "unsupported",
+        "vocabulary_version": "2026-07-13.v1",
+        "matches": [],
+        "ambiguities": [],
+    }

--- a/chatbot/chatbot-include.html
+++ b/chatbot/chatbot-include.html
@@ -1,4 +1,5 @@
 <link rel="stylesheet" href="/chatbot/chatbot.css">
 <script src="/chatbot/embedding-demo.js?v=56c5f57a" defer></script>
+<script src="/chatbot/icd-keyword.js?v=issue28" defer></script>
 <script src="/chatbot/profile-session.js?v=issue25" defer></script>
-<script src="/chatbot/chatbot.js?v=issue25" defer></script>
+<script src="/chatbot/chatbot.js?v=issue28" defer></script>

--- a/chatbot/chatbot.css
+++ b/chatbot/chatbot.css
@@ -604,6 +604,24 @@
   font-size: 0.72rem;
 }
 
+.chatbot-icd-title {
+  margin-top: 0.35rem;
+  color: #273444;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.chatbot-icd-selector {
+  display: inline-block;
+  margin-top: 0.28rem;
+  padding: 0.15rem 0.38rem;
+  border-radius: 5px;
+  background: #2c5aa0;
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
 .chatbot-disease-select {
   max-width: 100%;
   padding: 0.5rem;
@@ -1051,6 +1069,15 @@
 .quarto-dark .chatbot-demo-copy,
 .quarto-dark .chatbot-demo-status {
   color: #c0c7cf;
+}
+
+.quarto-dark .chatbot-icd-title {
+  color: #e5edf5;
+}
+
+.quarto-dark .chatbot-icd-selector {
+  background: #2c5aa0;
+  color: #fff;
 }
 
 .quarto-dark .chatbot-disease-btn {

--- a/chatbot/chatbot.js
+++ b/chatbot/chatbot.js
@@ -2,6 +2,7 @@
   "use strict";
 
   var DEMO = window.ALIGATEHR_EMBEDDING_DEMO;
+  var ICD = window.ALIGATEHR_ICD_KEYWORD;
   var PROFILE = window.ALIGATEHR_PROFILE_SESSION;
   var API_URL = DEMO.resolveApiUrl(window.location, window.ALIGATEHR_API_URL);
   var STORAGE_PREFIX = "aligatehr-chatbot-";
@@ -226,6 +227,7 @@
     if (action === "confirm-demo-profile") confirmDemoProfile(button);
     if (action === "compare-confirmed-profile") compareConfirmedProfile(button);
     if (action === "view-matched-references") viewMatchedReferences(button);
+    if (action === "view-icd-keyword") viewIcdKeyword(button);
     if (action === "start-over-demo-profile") startOverDemoProfile();
   });
 
@@ -308,19 +310,88 @@
     }
   }
 
-  function findUseCaseUrl() {
+  function findVisualizationUrl(path, hash) {
     var links = document.querySelectorAll('a[href]');
     for (var i = 0; i < links.length; i++) {
       var candidate = new URL(links[i].href, window.location.href);
-      if (candidate.pathname.endsWith("/viz/use-case.html")) {
-        candidate.hash = "fibrotic-embedding";
+      if (candidate.pathname.endsWith(path)) {
+        candidate.hash = hash;
         return candidate.href;
       }
     }
     var script = document.querySelector('script[src*="/chatbot/chatbot.js"]');
     var scriptUrl = new URL(script ? script.src : "/chatbot/chatbot.js", window.location.href);
     var siteRoot = scriptUrl.pathname.replace(/\/chatbot\/chatbot\.js$/, "");
-    return scriptUrl.origin + siteRoot + "/viz/use-case.html#fibrotic-embedding";
+    return scriptUrl.origin + siteRoot + path + "#" + hash;
+  }
+
+  function findUseCaseUrl() {
+    return findVisualizationUrl("/viz/use-case.html", "fibrotic-embedding");
+  }
+
+  function findPerformanceUrl() {
+    return findVisualizationUrl("/viz/overall-performance.html", "icd-embedding");
+  }
+
+  function renderIcdKeywordMatches(ui) {
+    var matches = Array.isArray(ui.matches) ? ui.matches : [];
+    matches.forEach(function (match, index) {
+      var card = createEl(
+        "div",
+        "chatbot-msg chatbot-msg-assistant chatbot-demo-card chatbot-icd-card",
+      );
+      var label = createEl("div", "chatbot-demo-label");
+      label.textContent = matches.length > 1
+        ? "ICD Keyword Match " + (index + 1) + " of " + matches.length
+        : "ICD Keyword Match";
+      var title = createEl("div", "chatbot-icd-title");
+      title.textContent = match.display_label;
+      var selector = createEl("code", "chatbot-icd-selector");
+      selector.textContent = match.selector_label;
+      var copy = createEl("p", "chatbot-demo-copy");
+      copy.textContent =
+        "Reviewed code selector for graph navigation only. It does not use ICD " +
+        "history, a Demo Profile, or patient-level similarity.";
+      var button = createEl("button", "chatbot-demo-button", {
+        type: "button",
+        "data-chatbot-action": "view-icd-keyword",
+      });
+      button.textContent = "View ICD: " + match.display_label + " (" + match.selector_label + ")";
+      button.setAttribute("data-icd-match", JSON.stringify(match));
+      button.setAttribute("data-vocabulary-version", ui.vocabulary_version);
+      var status = createEl("div", "chatbot-demo-status", { "aria-live": "polite" });
+      card.append(label, title, selector, copy, button, status);
+      addRawElement(card);
+    });
+  }
+
+  function viewIcdKeyword(button) {
+    if (button.disabled) return;
+    var status = button.parentElement.querySelector(".chatbot-demo-status");
+    try {
+      var match = JSON.parse(button.getAttribute("data-icd-match"));
+      var request = ICD.createRequest(
+        match,
+        button.getAttribute("data-vocabulary-version"),
+      );
+      ICD.saveRequest(sessionStorage, request);
+      ICD.notifyRequest(window, request);
+      var destination = new URL(findPerformanceUrl());
+      var samePage =
+        destination.origin === window.location.origin &&
+        destination.pathname === window.location.pathname;
+      status.textContent = "Opening this reviewed ICD selector on the code graph.";
+      if (samePage) {
+        window.location.hash = destination.hash;
+        button.textContent = "Show this ICD match again";
+        status.textContent = "ICD points highlighted. Explanation and reset controls are below.";
+      } else {
+        window.location.assign(destination.href);
+      }
+    } catch (error) {
+      status.textContent = "This ICD visualization request is unavailable. Ask for the keyword again.";
+      console.error("ICD Keyword Match visualization error:", error);
+    }
   }
 
   function startPresetDemo(button) {
@@ -1064,6 +1135,9 @@
         }
         if (data.ui && data.ui.type === "pathway_enrichment") {
           renderPathwayEnrichment(data.ui);
+        }
+        if (data.ui && data.ui.type === "icd_keyword_matches") {
+          renderIcdKeywordMatches(data.ui);
         }
       })
       .catch(function (err) {

--- a/chatbot/icd-keyword.js
+++ b/chatbot/icd-keyword.js
@@ -1,0 +1,115 @@
+(function (root, factory) {
+  var api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  if (root) root.ALIGATEHR_ICD_KEYWORD = api;
+})(typeof window !== "undefined" ? window : globalThis, function () {
+  "use strict";
+
+  var REQUEST_KEY = "aligatehr-icd-keyword-visualization-request";
+  var REQUEST_EVENT = "aligatehr:icd-keyword-visualization-request";
+
+  function copySelector(selector) {
+    if (!selector || !["exact", "prefix", "range"].includes(selector.type)) {
+      return null;
+    }
+    if (selector.type === "exact" && selector.code) {
+      return { type: "exact", code: String(selector.code) };
+    }
+    if (selector.type === "prefix" && selector.prefix) {
+      return { type: "prefix", prefix: String(selector.prefix) };
+    }
+    if (selector.type === "range" && selector.start && selector.end) {
+      return {
+        type: "range",
+        start: String(selector.start),
+        end: String(selector.end),
+      };
+    }
+    return null;
+  }
+
+  function createRequest(match, vocabularyVersion, createdAt) {
+    var selector = copySelector(match && match.selector);
+    if (
+      !match ||
+      !match.id ||
+      !match.display_label ||
+      !match.selector_label ||
+      !vocabularyVersion ||
+      !selector
+    ) {
+      throw new Error("Match is missing the ICD visualization contract");
+    }
+    return {
+      type: "icd_keyword_match",
+      vocabulary_version: vocabularyVersion,
+      keyword_id: match.id,
+      display_label: match.display_label,
+      selector: selector,
+      selector_label: match.selector_label,
+      created_at: createdAt || new Date().toISOString(),
+      consumed: false,
+    };
+  }
+
+  function saveRequest(storage, request) {
+    storage.setItem(REQUEST_KEY, JSON.stringify(request));
+  }
+
+  function consumeRequest(storage) {
+    var raw = storage.getItem(REQUEST_KEY);
+    if (!raw) return { status: "empty", request: null, should_play: false };
+    var request;
+    try {
+      request = JSON.parse(raw);
+    } catch (_error) {
+      storage.removeItem(REQUEST_KEY);
+      return { status: "invalid", request: null, should_play: false };
+    }
+    try {
+      createRequest(
+        {
+          id: request.keyword_id,
+          display_label: request.display_label,
+          selector: request.selector,
+          selector_label: request.selector_label,
+        },
+        request.vocabulary_version,
+        request.created_at,
+      );
+    } catch (_error) {
+      storage.removeItem(REQUEST_KEY);
+      return { status: "invalid", request: null, should_play: false };
+    }
+    var shouldPlay = request.consumed !== true;
+    request.consumed = true;
+    saveRequest(storage, request);
+    return { status: "ready", request: request, should_play: shouldPlay };
+  }
+
+  function notifyRequest(target, request) {
+    if (!target || typeof target.dispatchEvent !== "function") return;
+    target.dispatchEvent(new CustomEvent(REQUEST_EVENT, { detail: request }));
+  }
+
+  function connectRequestConsumer(target, storage, play) {
+    function consumeAndPlay() {
+      var latest = consumeRequest(storage);
+      if (latest.status === "ready" && latest.should_play) play(latest.request);
+    }
+    target.addEventListener(REQUEST_EVENT, consumeAndPlay);
+    return function () {
+      target.removeEventListener(REQUEST_EVENT, consumeAndPlay);
+    };
+  }
+
+  return {
+    REQUEST_KEY: REQUEST_KEY,
+    REQUEST_EVENT: REQUEST_EVENT,
+    createRequest: createRequest,
+    saveRequest: saveRequest,
+    consumeRequest: consumeRequest,
+    notifyRequest: notifyRequest,
+    connectRequestConsumer: connectRequestConsumer,
+  };
+});

--- a/chatbot/icd-keyword.test.cjs
+++ b/chatbot/icd-keyword.test.cjs
@@ -1,0 +1,98 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const icd = require("./icd-keyword.js");
+const demo = require("./embedding-demo.js");
+
+
+function memoryStorage() {
+  const values = new Map();
+  return {
+    getItem(key) {
+      return values.has(key) ? values.get(key) : null;
+    },
+    setItem(key, value) {
+      values.set(key, String(value));
+    },
+    removeItem(key) {
+      values.delete(key);
+    },
+  };
+}
+
+
+const tuberculosis = {
+  id: "tuberculosis",
+  canonical_keyword: "tuberculosis",
+  matched_keyword: "tb",
+  display_label: "Tuberculosis",
+  selector: { type: "range", start: "A15", end: "A19" },
+  selector_label: "A15-A19",
+};
+
+
+test("ICD action stores only one inspectable selector on its own request channel", () => {
+  const request = icd.createRequest(
+    tuberculosis,
+    "2026-07-13.v1",
+    "2026-07-13T12:00:00.000Z",
+  );
+
+  assert.notEqual(icd.REQUEST_KEY, demo.REQUEST_KEY);
+  assert.deepEqual(request, {
+    type: "icd_keyword_match",
+    vocabulary_version: "2026-07-13.v1",
+    keyword_id: "tuberculosis",
+    display_label: "Tuberculosis",
+    selector: { type: "range", start: "A15", end: "A19" },
+    selector_label: "A15-A19",
+    created_at: "2026-07-13T12:00:00.000Z",
+    consumed: false,
+  });
+  assert.equal(JSON.stringify(request).includes("profile"), false);
+  assert.equal(JSON.stringify(request).includes("visual_reference"), false);
+});
+
+
+test("each ICD match is consumed independently once and remains resettable", () => {
+  const storage = memoryStorage();
+  const request = icd.createRequest(tuberculosis, "2026-07-13.v1");
+  icd.saveRequest(storage, request);
+
+  const first = icd.consumeRequest(storage);
+  const second = icd.consumeRequest(storage);
+
+  assert.equal(first.should_play, true);
+  assert.equal(second.should_play, false);
+  assert.deepEqual(second.request.selector, tuberculosis.selector);
+});
+
+
+test("invalid or unreviewed selector shapes are rejected", () => {
+  assert.throws(
+    () => icd.createRequest({ ...tuberculosis, selector: { type: "range", start: "A15" } }, "v1"),
+    /missing the ICD visualization contract/,
+  );
+  assert.throws(
+    () => icd.createRequest({ ...tuberculosis, selector: { type: "nearest" } }, "v1"),
+    /missing the ICD visualization contract/,
+  );
+});
+
+
+test("same-page ICD event delivers the exact single action", () => {
+  const storage = memoryStorage();
+  const target = new EventTarget();
+  const request = icd.createRequest(tuberculosis, "2026-07-13.v1");
+  let played;
+  const disconnect = icd.connectRequestConsumer(target, storage, (latest) => {
+    played = latest;
+  });
+
+  icd.saveRequest(storage, request);
+  icd.notifyRequest(target, request);
+  disconnect();
+
+  assert.equal(played.keyword_id, "tuberculosis");
+  assert.deepEqual(played.selector, tuberculosis.selector);
+});

--- a/viz/icd-keyword-scatter.js
+++ b/viz/icd-keyword-scatter.js
@@ -1,0 +1,403 @@
+function normalizeCode(value) {
+  return String(value || "").toUpperCase().replace(/[^A-Z0-9]/g, "");
+}
+
+
+function selectorPredicate(selector) {
+  if (selector && selector.type === "exact" && selector.code) {
+    const code = normalizeCode(selector.code);
+    return (point) => normalizeCode(point.code) === code;
+  }
+  if (selector && selector.type === "prefix" && selector.prefix) {
+    const prefix = normalizeCode(selector.prefix);
+    return (point) => normalizeCode(point.code).startsWith(prefix);
+  }
+  if (selector && selector.type === "range" && selector.start && selector.end) {
+    const start = normalizeCode(selector.start).slice(0, 3);
+    const end = normalizeCode(selector.end).slice(0, 3);
+    return (point) => {
+      const category = normalizeCode(point.code).slice(0, 3);
+      return category.length === 3 && start <= category && category <= end;
+    };
+  }
+  throw new Error("The visualization request has an unsupported ICD selector");
+}
+
+
+export function resolveIcdIndices(data, selector) {
+  const matches = selectorPredicate(selector);
+  return data
+    .map((point, index) => (matches(point) ? index : null))
+    .filter((index) => index !== null);
+}
+
+
+function motionOptions(reducedMotion, padding) {
+  return {
+    padding,
+    transition: !reducedMotion,
+    transitionDuration: reducedMotion ? 0 : 520,
+  };
+}
+
+
+export function createIcdInteraction(config) {
+  const allIndices = config.data.map((_, index) => index);
+
+  return {
+    async focus(request, animate = !config.reducedMotion) {
+      const indices = resolveIcdIndices(config.data, request.selector);
+      if (!indices.length) {
+        throw new Error("The reviewed ICD selector matches no graph points");
+      }
+      await config.renderer.drawHighlighted(indices);
+      await config.renderer.zoomToPoints(
+        indices,
+        motionOptions(config.reducedMotion || !animate, 0.3),
+      );
+      const pointNoun = indices.length === 1 ? "point" : "points";
+      return {
+        indices,
+        explanation:
+          `${request.display_label} · ${request.selector_label} · ` +
+          `${indices.length.toLocaleString()} ICD graph ${pointNoun} highlighted. ` +
+          "Navigation context only; this does not represent patient history, " +
+          "diagnosis, or clinical similarity.",
+      };
+    },
+
+    async reset(animate = !config.reducedMotion) {
+      await config.renderer.drawOverview();
+      await config.renderer.zoomToPoints(
+        allIndices,
+        motionOptions(config.reducedMotion || !animate, 0.08),
+      );
+    },
+  };
+}
+
+
+export function createIcdRequestQueue() {
+  let generation = 0;
+  let tail = Promise.resolve();
+
+  return {
+    enqueue(task) {
+      generation += 1;
+      const token = generation;
+      const isCurrent = () => token === generation;
+      const run = tail.catch(() => {}).then(() => task(isCurrent));
+      tail = run.catch(() => {});
+      return run;
+    },
+    cancel() {
+      generation += 1;
+    },
+  };
+}
+
+
+function normalizePoints(data) {
+  const xs = data.map((point) => Number(point.umap_1));
+  const ys = data.map((point) => Number(point.umap_2));
+  const xMin = Math.min(...xs);
+  const xMax = Math.max(...xs);
+  const yMin = Math.min(...ys);
+  const yMax = Math.max(...ys);
+  const xMid = (xMin + xMax) / 2;
+  const yMid = (yMin + yMax) / 2;
+  const span = Math.max(xMax - xMin, yMax - yMin) || 1;
+  return data.map((point) => ({
+    x: ((Number(point.umap_1) - xMid) / span) * 1.9,
+    y: ((Number(point.umap_2) - yMid) / span) * 1.9,
+  }));
+}
+
+
+function fitWidth(maxWidth) {
+  const main = document.querySelector("main.content") || document.querySelector("main");
+  const mainWidth = main?.clientWidth || maxWidth;
+  const viewportWidth = document.documentElement.clientWidth - 32;
+  return Math.floor(Math.min(maxWidth, Math.max(320, Math.min(mainWidth, viewportWidth))));
+}
+
+
+function element(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text) node.textContent = text;
+  return node;
+}
+
+
+export async function createIcdKeywordScatter(config) {
+  const data = config.data;
+  const normalized = normalizePoints(data);
+  const allIndices = data.map((_, index) => index);
+  const chapters = [...new Set(data.map((point) => point.chapter))];
+  const chapterIndex = new Map(chapters.map((chapter, index) => [chapter, index]));
+  const colors = config.colors;
+  const width = fitWidth(config.width || 1000);
+  const height = Math.max(380, Math.round(width * 0.62));
+  const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  const shell = element("section", "embedding-walkthrough icd-keyword-walkthrough");
+  shell.setAttribute("aria-label", "ICD Keyword Match walkthrough");
+
+  const heading = element("div", "embedding-heading");
+  const title = document.createElement("div");
+  title.append(
+    element("strong", "", "UMAP of ICD-10 Code Embeddings"),
+    element("span", "", `${data.length.toLocaleString()} tracked codes · navigation context only`),
+  );
+  const vocabularyBadge = element("code", "", "Reviewed ICD vocabulary");
+  heading.append(title, vocabularyBadge);
+  shell.appendChild(heading);
+
+  const frame = element("div", "embedding-frame");
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+  canvas.setAttribute("role", "img");
+  canvas.setAttribute("aria-label", `${data.length.toLocaleString()} ICD code embedding points`);
+  canvas.tabIndex = 0;
+  frame.appendChild(canvas);
+  const tooltip = element("div", "embedding-tooltip");
+  frame.appendChild(tooltip);
+  shell.appendChild(frame);
+
+  const controls = element("div", "embedding-controls");
+  const status = element("span", "embedding-status", "Overview · waiting for an ICD Keyword Match action");
+  status.setAttribute("aria-live", "polite");
+  const replayButton = element("button", "embedding-button", "Replay highlight");
+  replayButton.type = "button";
+  replayButton.hidden = true;
+  const resetButton = element("button", "embedding-button", "Reset view");
+  resetButton.type = "button";
+  controls.append(status, replayButton, resetButton);
+  shell.appendChild(controls);
+
+  const summary = element("aside", "embedding-summary icd-keyword-summary");
+  summary.setAttribute("role", "region");
+  summary.setAttribute("aria-label", "ICD Keyword Match explanation");
+  summary.setAttribute("aria-live", "polite");
+  summary.tabIndex = -1;
+  summary.hidden = true;
+  shell.appendChild(summary);
+
+  const legend = element("div", "embedding-legend");
+  chapters.forEach((chapter, index) => {
+    const item = document.createElement("span");
+    const marker = document.createElement("i");
+    marker.style.background = colors[index % colors.length];
+    item.append(marker, document.createTextNode(chapter));
+    legend.appendChild(item);
+  });
+  shell.appendChild(legend);
+
+  const scatterplot = config.createScatterplot({
+    canvas,
+    width,
+    height,
+    pointSize: 3,
+    opacity: 0.78,
+    lassoOnLongPress: false,
+  });
+  const columns = {
+    x: normalized.map((point) => point.x),
+    y: normalized.map((point) => point.y),
+  };
+
+  async function drawOverview() {
+    scatterplot.set({
+      colorBy: "valueA",
+      opacityBy: null,
+      sizeBy: null,
+      pointColor: colors,
+      opacity: 0.78,
+      pointSize: 3,
+    });
+    await scatterplot.draw({
+      ...columns,
+      z: data.map((point) => chapterIndex.get(point.chapter)),
+    });
+    scatterplot.deselect({ preventEvent: true });
+  }
+
+  async function drawHighlighted(indices) {
+    const selected = new Set(indices);
+    scatterplot.set({
+      colorBy: "valueA",
+      opacityBy: "valueA",
+      sizeBy: "valueA",
+      pointColor: ["#aeb7c2", "#2c5aa0"],
+      opacity: [0.1, 1],
+      pointSize: [2.3, 8],
+    });
+    await scatterplot.draw(
+      {
+        ...columns,
+        z: data.map((_, index) => (selected.has(index) ? 1 : 0)),
+      },
+      { preventFilterReset: true },
+    );
+    scatterplot.select(indices, { preventEvent: true });
+  }
+
+  const interaction = createIcdInteraction({
+    data,
+    reducedMotion,
+    renderer: {
+      drawOverview,
+      drawHighlighted,
+      zoomToPoints: (indices, options) => scatterplot.zoomToPoints(indices, options),
+    },
+  });
+  const requestQueue = createIcdRequestQueue();
+  let activeRequest = config.request || null;
+  let motionActive = false;
+
+  function showExplanation(request, result) {
+    summary.replaceChildren();
+    summary.setAttribute("role", "region");
+    const kicker = element("div", "embedding-summary-kicker", "ICD Keyword Match");
+    const title = element("h3", "", `${request.display_label} (${request.selector_label})`);
+    const copy = element("p", "", result.explanation);
+    const note = element(
+      "p",
+      "embedding-summary-note",
+      "The selected points are code-embedding nodes. They are not a patient profile, diagnosis, or similarity result.",
+    );
+    summary.append(kicker, title, copy, note);
+    summary.hidden = false;
+    replayButton.hidden = false;
+    vocabularyBadge.textContent = request.vocabulary_version;
+    const pointNoun = result.indices.length === 1 ? "point" : "points";
+    status.textContent = `${result.indices.length.toLocaleString()} ICD graph ${pointNoun} highlighted`;
+    summary.focus({ preventScroll: true });
+  }
+
+  function setControlsBusy(busy) {
+    resetButton.disabled = busy;
+    replayButton.disabled = busy;
+  }
+
+  function focus(request, animate = !reducedMotion) {
+    activeRequest = request;
+    status.textContent = `Highlighting ${request.display_label} (${request.selector_label})`;
+    setControlsBusy(true);
+    motionActive = true;
+    return requestQueue.enqueue(async (isCurrent) => {
+      try {
+        await interaction.reset(false);
+        if (!isCurrent()) return;
+        const result = await interaction.focus(request, animate);
+        if (!isCurrent()) return;
+        showExplanation(request, result);
+      } catch (error) {
+        if (!isCurrent()) return;
+        summary.hidden = false;
+        summary.textContent = error.message;
+        summary.setAttribute("role", "alert");
+        status.textContent = "The ICD request could not be shown";
+      } finally {
+        if (isCurrent()) {
+          motionActive = false;
+          setControlsBusy(false);
+        }
+      }
+    });
+  }
+
+  function reset(message = "Overview · ICD Keyword Match reset", animate = !reducedMotion) {
+    setControlsBusy(true);
+    motionActive = true;
+    return requestQueue.enqueue(async (isCurrent) => {
+      try {
+        await interaction.reset(animate);
+        if (!isCurrent()) return;
+        summary.hidden = true;
+        summary.setAttribute("role", "region");
+        replayButton.hidden = activeRequest === null;
+        status.textContent = message;
+      } finally {
+        if (isCurrent()) {
+          motionActive = false;
+          setControlsBusy(false);
+        }
+      }
+    });
+  }
+
+  replayButton.addEventListener("click", () => {
+    if (activeRequest) focus(activeRequest);
+  });
+  resetButton.addEventListener("click", () => reset());
+  scatterplot.subscribe("pointover", (index) => {
+    const point = data[index];
+    if (!point) return;
+    tooltip.textContent = `${point.code} · ${point.chapter}`;
+    tooltip.classList.add("is-visible");
+  });
+  scatterplot.subscribe("pointout", () => tooltip.classList.remove("is-visible"));
+  canvas.addEventListener("mousemove", (event) => {
+    const rect = canvas.getBoundingClientRect();
+    tooltip.style.left = `${event.clientX - rect.left + 12}px`;
+    tooltip.style.top = `${event.clientY - rect.top + 12}px`;
+  });
+
+  function cancelForInteraction() {
+    if (motionActive) reset("Walkthrough paused by visitor interaction", false);
+  }
+
+  function cancelForVisibility() {
+    if (document.hidden && motionActive) {
+      reset("Walkthrough paused while this tab is hidden", false);
+    }
+  }
+
+  function cancelForRouteChange() {
+    requestQueue.cancel();
+    motionActive = false;
+  }
+
+  canvas.addEventListener("pointerdown", cancelForInteraction);
+  document.addEventListener("visibilitychange", cancelForVisibility);
+  window.addEventListener("pagehide", cancelForRouteChange);
+
+  await drawOverview();
+  await scatterplot.zoomToPoints(allIndices, { padding: 0.08 });
+
+  if (!activeRequest && config.searchQuery) {
+    const query = config.searchQuery.toLowerCase();
+    const searchIndices = data
+      .map((point, index) => (
+        point.code.toLowerCase().includes(query) || point.chapter.toLowerCase().includes(query)
+          ? index
+          : null
+      ))
+      .filter((index) => index !== null);
+    if (searchIndices.length) {
+      await drawHighlighted(searchIndices);
+      status.textContent = `Manual search · ${searchIndices.length.toLocaleString()} matching code nodes`;
+    } else {
+      status.textContent = "Manual search · no matching code nodes";
+    }
+  }
+
+  if (activeRequest) {
+    window.setTimeout(() => focus(activeRequest, config.autoplay !== false), 80);
+  }
+
+  function destroy() {
+    requestQueue.cancel();
+    motionActive = false;
+    document.removeEventListener("visibilitychange", cancelForVisibility);
+    window.removeEventListener("pagehide", cancelForRouteChange);
+  }
+
+  shell.icdKeywordWalkthrough = { focus, reset, destroy };
+  return shell;
+}

--- a/viz/icd-keyword-scatter.js
+++ b/viz/icd-keyword-scatter.js
@@ -77,21 +77,38 @@ export function createIcdInteraction(config) {
 }
 
 
-export function createIcdRequestQueue() {
+export function createIcdRequestQueue(interruptActiveMotion = () => {}) {
   let generation = 0;
   let tail = Promise.resolve();
+  let hasWork = false;
+
+  function interrupt() {
+    try {
+      return Promise.resolve(interruptActiveMotion()).catch(() => {});
+    } catch (_error) {
+      return Promise.resolve();
+    }
+  }
 
   return {
     enqueue(task) {
       generation += 1;
       const token = generation;
+      const interruption = hasWork ? interrupt() : Promise.resolve();
+      hasWork = true;
       const isCurrent = () => token === generation;
-      const run = tail.catch(() => {}).then(() => task(isCurrent));
-      tail = run.catch(() => {});
+      const run = Promise.all([tail.catch(() => {}), interruption])
+        .then(() => task(isCurrent));
+      tail = run.catch(() => {}).finally(() => {
+        if (isCurrent()) hasWork = false;
+      });
       return run;
     },
     cancel() {
       generation += 1;
+      const interruption = hasWork ? interrupt() : Promise.resolve();
+      hasWork = false;
+      return interruption;
     },
   };
 }
@@ -255,7 +272,13 @@ export async function createIcdKeywordScatter(config) {
       zoomToPoints: (indices, options) => scatterplot.zoomToPoints(indices, options),
     },
   });
-  const requestQueue = createIcdRequestQueue();
+  const requestQueue = createIcdRequestQueue(() => {
+    return scatterplot.zoomToPoints(allIndices, {
+      padding: 0.08,
+      transition: true,
+      transitionDuration: 0,
+    });
+  });
   let activeRequest = config.request || null;
   let motionActive = false;
 

--- a/viz/icd-keyword-scatter.test.mjs
+++ b/viz/icd-keyword-scatter.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createIcdInteraction,
+  createIcdRequestQueue,
+  resolveIcdIndices,
+} from "./icd-keyword-scatter.js";
+
+
+const data = [
+  { code: "A14" },
+  { code: "A15" },
+  { code: "A150" },
+  { code: "A19" },
+  { code: "A191" },
+  { code: "A20" },
+  { code: "E11" },
+  { code: "E110" },
+  { code: "N18" },
+  { code: "N180" },
+];
+
+
+test("exact, prefix, and inclusive range selectors resolve tracked graph points", () => {
+  assert.deepEqual(resolveIcdIndices(data, { type: "exact", code: "E11" }), [6]);
+  assert.deepEqual(resolveIcdIndices(data, { type: "prefix", prefix: "N18" }), [8, 9]);
+  assert.deepEqual(
+    resolveIcdIndices(data, { type: "range", start: "A15", end: "A19" }),
+    [1, 2, 3, 4],
+  );
+  assert.throws(
+    () => resolveIcdIndices(data, { type: "nearest", code: "E11" }),
+    /unsupported ICD selector/,
+  );
+});
+
+
+test("ICD interaction highlights, explains, jumps, and resets without patient data", async () => {
+  const calls = [];
+  const renderer = {
+    drawHighlighted: async (indices) => calls.push(["highlight", indices]),
+    drawOverview: async () => calls.push(["overview"]),
+    zoomToPoints: async (indices, options) => calls.push(["zoom", indices, options]),
+  };
+  const interaction = createIcdInteraction({ data, renderer, reducedMotion: false });
+  const request = {
+    type: "icd_keyword_match",
+    display_label: "Tuberculosis",
+    selector_label: "A15-A19",
+    selector: { type: "range", start: "A15", end: "A19" },
+  };
+
+  const result = await interaction.focus(request);
+  await interaction.reset();
+
+  assert.deepEqual(result, {
+    indices: [1, 2, 3, 4],
+    explanation: "Tuberculosis · A15-A19 · 4 ICD graph points highlighted. Navigation context only; this does not represent patient history, diagnosis, or clinical similarity.",
+  });
+  assert.deepEqual(calls, [
+    ["highlight", [1, 2, 3, 4]],
+    ["zoom", [1, 2, 3, 4], { padding: 0.3, transition: true, transitionDuration: 520 }],
+    ["overview"],
+    ["zoom", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], { padding: 0.08, transition: true, transitionDuration: 520 }],
+  ]);
+});
+
+
+test("reduced motion jumps directly to the final highlighted state", async () => {
+  const calls = [];
+  const interaction = createIcdInteraction({
+    data,
+    reducedMotion: true,
+    renderer: {
+      drawHighlighted: async () => calls.push("highlight"),
+      drawOverview: async () => calls.push("overview"),
+      zoomToPoints: async (_indices, options) => calls.push(options),
+    },
+  });
+
+  await interaction.focus({
+    display_label: "Chronic kidney disease",
+    selector_label: "N18*",
+    selector: { type: "prefix", prefix: "N18" },
+  });
+
+  assert.deepEqual(calls, [
+    "highlight",
+    { padding: 0.3, transition: false, transitionDuration: 0 },
+  ]);
+});
+
+
+test("new ICD requests invalidate stale work and run in deterministic order", async () => {
+  const queue = createIcdRequestQueue();
+  const calls = [];
+  let releaseFirst;
+  const first = queue.enqueue(async (isCurrent) => {
+    calls.push("first-start");
+    await new Promise((resolve) => { releaseFirst = resolve; });
+    if (isCurrent()) calls.push("first-result");
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const second = queue.enqueue(async (isCurrent) => {
+    calls.push("second-start");
+    if (isCurrent()) calls.push("second-result");
+  });
+
+  releaseFirst();
+  await Promise.all([first, second]);
+
+  assert.deepEqual(calls, ["first-start", "second-start", "second-result"]);
+});

--- a/viz/icd-keyword-scatter.test.mjs
+++ b/viz/icd-keyword-scatter.test.mjs
@@ -92,10 +92,15 @@ test("reduced motion jumps directly to the final highlighted state", async () =>
 });
 
 
-test("new ICD requests invalidate stale work and run in deterministic order", async () => {
-  const queue = createIcdRequestQueue();
+test("new ICD requests interrupt stale motion before the next render starts", async () => {
   const calls = [];
   let releaseFirst;
+  let releaseInterrupt;
+  const queue = createIcdRequestQueue(() => {
+    calls.push("cancel-motion");
+    releaseFirst();
+    return new Promise((resolve) => { releaseInterrupt = resolve; });
+  });
   const first = queue.enqueue(async (isCurrent) => {
     calls.push("first-start");
     await new Promise((resolve) => { releaseFirst = resolve; });
@@ -106,9 +111,70 @@ test("new ICD requests invalidate stale work and run in deterministic order", as
     calls.push("second-start");
     if (isCurrent()) calls.push("second-result");
   });
+  await new Promise((resolve) => setTimeout(resolve, 0));
 
+  assert.deepEqual(calls, ["first-start", "cancel-motion"]);
+  releaseInterrupt();
+
+  await Promise.all([first, second]);
+
+  assert.deepEqual(calls, [
+    "first-start",
+    "cancel-motion",
+    "second-start",
+    "second-result",
+  ]);
+});
+
+
+test("explicit cancellation interrupts active motion and suppresses stale results", async () => {
+  const calls = [];
+  let release;
+  const queue = createIcdRequestQueue(() => {
+    calls.push("cancel-motion");
+    release();
+  });
+  const active = queue.enqueue(async (isCurrent) => {
+    await new Promise((resolve) => { release = resolve; });
+    if (isCurrent()) calls.push("stale-result");
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  await queue.cancel();
+  await active;
+
+  assert.deepEqual(calls, ["cancel-motion"]);
+});
+
+
+test("a synchronous interruption error cannot block the replacement request", async () => {
+  const calls = [];
+  let releaseFirst;
+  const queue = createIcdRequestQueue(() => {
+    calls.push("cancel-error");
+    throw new Error("renderer is already stopping");
+  });
+  const first = queue.enqueue(async (isCurrent) => {
+    calls.push("first-start");
+    await new Promise((resolve) => { releaseFirst = resolve; });
+    if (isCurrent()) calls.push("first-result");
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const second = queue.enqueue(async (isCurrent) => {
+    calls.push("second-start");
+    if (isCurrent()) calls.push("second-result");
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(calls, ["first-start", "cancel-error"]);
   releaseFirst();
   await Promise.all([first, second]);
 
-  assert.deepEqual(calls, ["first-start", "second-start", "second-result"]);
+  assert.deepEqual(calls, [
+    "first-start",
+    "cancel-error",
+    "second-start",
+    "second-result",
+  ]);
 });

--- a/viz/overall-performance.qmd
+++ b/viz/overall-performance.qmd
@@ -604,7 +604,15 @@ umapAge = {
 }
 ```
 
-## ICD-10 Code Embedding UMAP
+## ICD-10 Code Embedding UMAP {#icd-embedding}
+
+Use the chatbot to request a reviewed ICD Keyword Match, or search the tracked code nodes directly below. Keyword actions are navigation-only and remain separate from Demo Profile comparison.
+
+```{ojs}
+//| echo: false
+
+import { createIcdKeywordScatter } from "./icd-keyword-scatter.js"
+```
 
 ```{ojs}
 //| echo: false
@@ -626,68 +634,42 @@ viewof icdSearch = Inputs.text({ label: "Search ICD code or description", placeh
 
 icdUmap = {
   const query = icdSearch.toLowerCase().trim();
-  const hasQuery = query.length > 0;
-
   const schemeCategory20 = [
     "#1f77b4","#ff7f0e","#2ca02c","#d62728","#9467bd",
     "#8c564b","#e377c2","#7f7f7f","#bcbd22","#17becf",
     "#aec7e8","#ffbb78","#98df8a","#ff9896","#c5b0d5",
     "#c49c94","#f7b6d2","#c7c7c7","#dbdb8d","#9edae5"
   ];
-  const chapters = [...new Set(icdData.map(d => d.chapter))];
-  const chapterColorMap = {};
-  chapters.forEach((ch, i) => { chapterColorMap[ch] = schemeCategory20[i % 20]; });
-  const chapterIndexMap = {};
-  chapters.forEach((ch, i) => { chapterIndexMap[ch] = i; });
-
-  const plotData = icdData.map(d => {
-    const match = !hasQuery || d.code.toLowerCase().includes(query) || d.chapter.toLowerCase().includes(query);
-    return { ...d, match };
+  let removeRequestListener = () => {};
+  let chart = null;
+  invalidation.then(() => {
+    removeRequestListener();
+    if (chart) chart.icdKeywordWalkthrough.destroy();
   });
 
-  return reglDrilldownScatter({
-    data: plotData,
-    xField: "umap_1",
-    yField: "umap_2",
-    title: "UMAP of ICD-10 Code Embeddings",
-    subtitle: `${icdData.length.toLocaleString()} codes, coloured by ICD-10 chapter`,
-    scatterSet: {
-      colorBy: "valueA",
-      pointColor: chapters.map(ch => chapterColorMap[ch]),
-      opacityBy: "valueB",
-      opacity: hasQuery ? [0.08, 0.9] : [0.8, 0.8],
-      sizeBy: "valueB",
-      pointSize: hasQuery ? [2.5, 5] : [3, 3],
-    },
-    drawOptions: {
-      zDataType: "categorical",
-      wDataType: "categorical",
-    },
-    zValues: plotData.map(d => chapterIndexMap[d.chapter]),
-    wValues: plotData.map(d => hasQuery ? (d.match ? 1 : 0) : 1),
-    groupAccessor: d => d.chapter,
-    groupLabel: value => value,
-    countNoun: "codes",
-    tooltip: d => `<strong>${d.code}</strong><br>Chapter: ${d.chapter}`,
-    renderLegend: (legend, { drillGroup }) => {
-      legend.style.cssText = "display:grid;grid-template-columns:repeat(4,1fr);gap:4px 16px;font-size:0.8rem;";
-      for (const ch of chapters) {
-        const count = icdData.filter(d => d.chapter === ch).length;
-        const item = document.createElement("span");
-        item.className = "drilldown-legend-item";
-        item.tabIndex = 0;
-        item.innerHTML = `<span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:${chapterColorMap[ch]};margin-right:4px;vertical-align:middle;"></span>${ch} (${count})`;
-        item.addEventListener("click", () => drillGroup(ch));
-        item.addEventListener("keydown", event => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            drillGroup(ch);
-          }
-        });
-        legend.appendChild(item);
-      }
-    },
+  let helper = window.ALIGATEHR_ICD_KEYWORD;
+  for (let attempt = 0; !helper && attempt < 20; attempt += 1) {
+    await new Promise(resolve => window.setTimeout(resolve, 50));
+    helper = window.ALIGATEHR_ICD_KEYWORD;
+  }
+  if (!helper) throw new Error("The ICD visualization request helper is unavailable.");
+
+  const consumed = helper.consumeRequest(sessionStorage);
+  chart = await createIcdKeywordScatter({
+    data: icdData,
+    createScatterplot,
+    colors: schemeCategory20,
+    searchQuery: query,
+    request: consumed.request,
+    autoplay: consumed.should_play,
   });
+  removeRequestListener = helper.connectRequestConsumer(
+    window,
+    sessionStorage,
+    request => chart.icdKeywordWalkthrough.focus(request),
+  );
+  window.__ALIGATEHR_ICD_READY__ = true;
+  return chart;
 }
 ```
 


### PR DESCRIPTION
Closes #28

## What changed

- adds a separate reviewed ICD Keyword Match flow with deterministic exact, prefix, and range selectors
- keeps multiple keyword matches as independent navigation actions, separate from Demo Profile and patient similarity
- adds jump, highlight, explanation, replay/reset, and reduced-motion behavior to the ICD graph
- hardens review findings so undeclared ambiguity fails closed and replacement requests actively interrupt stale camera motion while renderer writes remain serialized

## Validation

- `node --test chatbot/*.test.cjs viz/*.test.mjs` — 38 passed
- `python -m pytest -q chatbot-backend` — 120 passed
- `python scripts/check_ojs_assets.py` — passed
- `quarto render` — passed (pre-existing unresolved `viz/dashboard.qmd` warning only)
- local browser smoke: rapid Tuberculosis → CKD actions ended on CKD (9 points), reset restored Overview, local `/chat` returned 200

## Review

Two-axis standards/spec review completed. No remaining actionable blockers; shared renderer contraction remains scoped to #29.
