### PR TITLE
Make backend tests portable across repository layouts

### DIFF
--- a/chatbot-backend/test_icd_keyword.py
+++ b/chatbot-backend/test_icd_keyword.py
@@ -6,16 +6,29 @@ import pytest
 from icd_keyword import load_icd_vocabulary, match_icd_keywords, validate_vocabulary
 
 
-ROOT = Path(__file__).resolve().parents[1]
+SITE_ROOT = Path(__file__).resolve().parents[1]
+EMBEDDING_PATH = SITE_ROOT / "viz" / "data" / "icd_code_embeddings.csv"
 
 
 def embedding_codes():
-    path = ROOT / "viz" / "data" / "icd_code_embeddings.csv"
-    with path.open(newline="", encoding="utf-8") as handle:
+    with EMBEDDING_PATH.open(newline="", encoding="utf-8") as handle:
         return [row["code"] for row in csv.DictReader(handle)]
 
 
-def test_reviewed_vocabulary_selectors_exist_in_the_tracked_icd_embedding():
+def representative_selector_codes(vocabulary):
+    codes = []
+    for entry in vocabulary["entries"]:
+        selector = entry["selector"]
+        if selector["type"] == "exact":
+            codes.append(selector["code"])
+        elif selector["type"] == "prefix":
+            codes.append(selector["prefix"])
+        else:
+            codes.append(selector["start"])
+    return codes
+
+
+def test_reviewed_vocabulary_declares_its_version_and_selector_types():
     vocabulary = load_icd_vocabulary()
 
     assert vocabulary["version"] == "2026-07-13.v1"
@@ -26,6 +39,15 @@ def test_reviewed_vocabulary_selectors_exist_in_the_tracked_icd_embedding():
         "prefix",
         "range",
     }
+
+
+@pytest.mark.skipif(
+    not EMBEDDING_PATH.is_file(),
+    reason="full-site ICD embedding contract is checked only in the website repository",
+)
+def test_reviewed_vocabulary_selectors_exist_in_the_tracked_icd_embedding():
+    vocabulary = load_icd_vocabulary()
+
     assert validate_vocabulary(vocabulary, embedding_codes()) == []
 
 
@@ -85,7 +107,7 @@ def test_ambiguous_and_unsupported_input_never_produce_actions():
         ],
     }
 
-    assert validate_vocabulary(ambiguous_vocabulary, embedding_codes()) == []
+    assert validate_vocabulary(ambiguous_vocabulary, ["A00", "A01"]) == []
     ambiguous = match_icd_keywords("shared term", ambiguous_vocabulary)
     unsupported = match_icd_keywords("eczema")
 
@@ -111,7 +133,10 @@ def test_unreviewed_duplicate_terms_remain_vocabulary_errors():
 
     assert any(
         "is also assigned" in error
-        for error in validate_vocabulary(vocabulary, embedding_codes())
+        for error in validate_vocabulary(
+            vocabulary,
+            representative_selector_codes(vocabulary),
+        )
     )
     with pytest.raises(ValueError, match="ambiguous without a reviewed declaration"):
         match_icd_keywords(vocabulary["entries"][0]["canonical_keyword"], vocabulary)

--- a/chatbot-backend/test_research_data_release.py
+++ b/chatbot-backend/test_research_data_release.py
@@ -1,11 +1,9 @@
-from pathlib import Path
-
-from paper_context import PAPER_SOURCE, PAPER_TEXT
+from paper_context import PAPER_SOURCE, PAPER_SOURCE_SHA256, PAPER_TEXT
 from research_data_release import public_release_metadata, validate_release
 
 
-def test_research_result_release_matches_every_published_copy():
-    manifest = validate_release(include_published=True)
+def test_research_result_release_matches_its_versioned_contract():
+    manifest = validate_release(include_published=False)
     assert manifest["dataset_version"] == "research-results-mock-v1"
     assert manifest["status"] == "mock"
 
@@ -20,6 +18,7 @@ def test_public_release_metadata_is_explicit_and_path_free():
 
 def test_paper_context_is_generated_from_the_published_aligatehr_gen_page():
     assert PAPER_SOURCE == "report/old-report.qmd"
+    assert len(PAPER_SOURCE_SHA256) == 64
+    assert set(PAPER_SOURCE_SHA256) <= set("0123456789abcdef")
     assert "ALIGATEHR-Gen" in PAPER_TEXT
     assert "Bio-ALIGATEHR" not in PAPER_TEXT
-    assert Path(__file__).resolve().parents[1].joinpath(PAPER_SOURCE).is_file()


### PR DESCRIPTION
## What changed

- separates backend-owned release validation from website-level published-copy synchronization
- keeps the full-site ICD embedding contract active in the website repository while making standalone backend tests explicit about that boundary
- verifies generated paper context through its recorded source hash instead of requiring the source Quarto tree at runtime

## Why

The independently deployed backend repository mirrors `chatbot-backend/` at its root. Tests that reached into sibling `viz/` and `report/` directories passed only inside the full website checkout and failed in a clean backend mirror.

## Validation

- full website layout: `uv run --project chatbot-backend pytest chatbot-backend -q` — 164 passed
- website contracts: `pnpm run check:data`
- standalone backend layout: `uv run pytest -q` — 163 passed, 1 explicit full-site-only check skipped
